### PR TITLE
Gas cost optimisation

### DIFF
--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -186,6 +186,22 @@ library BTCUtils {
         }
     }
 
+    /// @notice          Implements bitcoin's hash256 on a pair of bytes32
+    /// @dev             sha2 is precompiled smart contract located at address(2)
+    /// @param _a        The first bytes32 of the pre-image
+    /// @param _b        The second bytes32 of the pre-image
+    /// @return res      The digest
+    function hash256Pair(bytes32 _a, bytes32 _b) internal view returns (bytes32 res) {
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            mstore(0x00, _a)
+            mstore(0x20, _b)
+            pop(staticcall(gas(), 2, 0x00, 64, 0x00, 32))
+            pop(staticcall(gas(), 2, 0x00, 32, 0x00, 32))
+            res := mload(0x00)
+        }
+    }
+
     /* ************ */
     /* Legacy Input */
     /* ************ */
@@ -636,8 +652,8 @@ library BTCUtils {
         return hash256(abi.encodePacked(_a, _b));
     }
 
-    function _hash256MerkleStep(bytes32 _a, bytes32 _b) internal pure returns (bytes32) {
-        return hash256(abi.encodePacked(_a, _b));
+    function _hash256MerkleStep(bytes32 _a, bytes32 _b) internal view returns (bytes32) {
+        return hash256Pair(_a, _b);
     }
 
 
@@ -646,7 +662,7 @@ library BTCUtils {
     /// @param _proof    The proof. Tightly packed LE sha256 hashes. The last hash is the root
     /// @param _index    The index of the leaf
     /// @return          true if the proof is valid, else false
-    function verifyHash256Merkle(bytes memory _proof, uint _index) internal pure returns (bool) {
+    function verifyHash256Merkle(bytes memory _proof, uint _index) internal view returns (bool) {
         // Not an even number of hashes
         if (_proof.length % 32 != 0) {
             return false;

--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -374,12 +374,20 @@ library BTCUtils {
         return _input.slice32(0);
     }
 
+    function extractInputTxIdLeAt(bytes memory _input, uint256 _at) internal pure returns (bytes32) {
+        return _input.slice32(_at);
+    }
+
     /// @notice          Extracts the LE tx input index from the input in a tx
     /// @dev             4-byte tx index
     /// @param _input    The input
     /// @return          The tx index (little-endian bytes)
     function extractTxIndexLE(bytes memory _input) internal pure returns (bytes4) {
         return _input.slice4(32);
+    }
+
+    function extractTxIndexLeAt(bytes memory _input, uint256 _at) internal pure returns (bytes4) {
+        return _input.slice4(32 + _at);
     }
 
     /* ****** */

--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -212,10 +212,9 @@ library BTCUtils {
     function hash256View(bytes memory _b) internal view returns (bytes32 res) {
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            let ptr := mload(0x40)
-            pop(staticcall(gas(), 2, add(_b, 32), mload(_b), ptr, 32))
-            pop(staticcall(gas(), 2, ptr, 32, ptr, 32))
-            res := mload(ptr)
+            pop(staticcall(gas(), 2, add(_b, 32), mload(_b), 0x00, 32))
+            pop(staticcall(gas(), 2, 0x00, 32, 0x00, 32))
+            res := mload(0x00)
         }
     }
 

--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -548,8 +548,7 @@ library BTCUtils {
             }
 
             // Grab the next input and determine its length.
-            bytes memory _next = _vin.slice(_offset, _vin.length - _offset);
-            uint256 _nextLen = determineInputLength(_next);
+            uint256 _nextLen = determineInputLengthAt(_vin, _offset);
             if (_nextLen == ERR_BAD_ARG) {
                 return false;
             }
@@ -587,8 +586,7 @@ library BTCUtils {
 
             // Grab the next output and determine its length.
             // Increase the offset by that much
-            bytes memory _next = _vout.slice(_offset, _vout.length - _offset);
-            uint256 _nextLen = determineOutputLength(_next);
+            uint256 _nextLen = determineOutputLengthAt(_vout, _offset);
             if (_nextLen == ERR_BAD_ARG) {
                 return false;
             }

--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -294,7 +294,7 @@ library BTCUtils {
     function determineInputLengthAt(bytes memory _input, uint256 _at) internal pure returns (uint256) {
         uint256 _varIntDataLen;
         uint256 _scriptSigLen;
-        (_varIntDataLen, _scriptSigLen) = extractScriptSigLen(_input, _at);
+        (_varIntDataLen, _scriptSigLen) = extractScriptSigLenAt(_input, _at);
         if (_varIntDataLen == ERR_BAD_ARG) {
             return ERR_BAD_ARG;
         }

--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -118,6 +118,10 @@ library BTCUtils {
         v = (v >> 16) | (v << 16);
     }
 
+    function reverseUint24(uint24 _b) internal pure returns (uint24 v) {
+        v =  (_b << 16) | (_b & 0x00FF00) | (_b >> 16);
+    }
+
     /// @notice          Converts big-endian bytes to a uint
     /// @dev             Traverses the byte array and sums the bytes
     /// @param _b        The big-endian bytes-encoded integer
@@ -574,9 +578,9 @@ library BTCUtils {
     /// @param _header   The header
     /// @return          The target threshold
     function extractTarget(bytes memory _header) internal pure returns (uint256) {
-        bytes memory _m = _header.slice(72, 3);
+        uint24 _m = uint24(_header.slice3(72));
         uint8 _e = uint8(_header[75]);
-        uint256 _mantissa = bytesToUint(reverseEndianness(_m));
+        uint256 _mantissa = uint256(reverseUint24(_m));
         uint _exponent = _e - 3;
 
         return _mantissa * (256 ** _exponent);

--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -30,6 +30,11 @@ library BTCUtils {
         return determineVarIntDataLengthAt(_flag, 0);
     }
 
+    /// @notice         Determines the length of a VarInt in bytes
+    /// @dev            A VarInt of >1 byte is prefixed with a flag indicating its length
+    /// @param _b       The byte array containing a VarInt
+    /// @param _at      The position of the VarInt in the array
+    /// @return         The number of non-flag bytes in the VarInt
     function determineVarIntDataLengthAt(bytes memory _b, uint256 _at) internal pure returns (uint8) {
         if (uint8(_b[_at]) == 0xff) {
             return 8;  // one-byte flag, 8 bytes data
@@ -53,6 +58,12 @@ library BTCUtils {
         return parseVarIntAt(_b, 0);
     }
 
+    /// @notice     Parse a VarInt into its data length and the number it represents
+    /// @dev        Useful for Parsing Vins and Vouts. Returns ERR_BAD_ARG if insufficient bytes.
+    ///             Caller SHOULD explicitly handle this case (or bubble it up)
+    /// @param _b   A byte-string containing a VarInt
+    /// @param _at  The position of the VarInt
+    /// @return     number of bytes in the encoding (not counting the tag), the encoded int
     function parseVarIntAt(bytes memory _b, uint256 _at) internal pure returns (uint256, uint256) {
         uint8 _dataLen = determineVarIntDataLengthAt(_b, _at);
 
@@ -110,6 +121,9 @@ library BTCUtils {
         v = (v >> 128) | (v << 128);
     }
 
+    /// @notice          Changes the endianness of a uint64
+    /// @param _b        The unsigned integer to reverse
+    /// @return v        The reversed value
     function reverseUint64(uint64 _b) internal pure returns (uint64 v) {
         v = _b;
 
@@ -123,6 +137,9 @@ library BTCUtils {
         v = (v >> 32) | (v << 32);
     }
 
+    /// @notice          Changes the endianness of a uint32
+    /// @param _b        The unsigned integer to reverse
+    /// @return v        The reversed value
     function reverseUint32(uint32 _b) internal pure returns (uint32 v) {
         v = _b;
 
@@ -133,10 +150,16 @@ library BTCUtils {
         v = (v >> 16) | (v << 16);
     }
 
+    /// @notice          Changes the endianness of a uint24
+    /// @param _b        The unsigned integer to reverse
+    /// @return v        The reversed value
     function reverseUint24(uint24 _b) internal pure returns (uint24 v) {
         v =  (_b << 16) | (_b & 0x00FF00) | (_b >> 16);
     }
 
+    /// @notice          Changes the endianness of a uint16
+    /// @param _b        The unsigned integer to reverse
+    /// @return v        The reversed value
     function reverseUint16(uint16 _b) internal pure returns (uint16 v) {
         v =  (_b << 8) | (_b >> 8);
     }
@@ -150,16 +173,6 @@ library BTCUtils {
         uint256 _number;
 
         for (uint i = 0; i < _b.length; i++) {
-            _number = _number + uint8(_b[i]) * (2 ** (8 * (_b.length - (i + 1))));
-        }
-
-        return _number;
-    }
-
-    function bytesToUint(bytes4 _b) internal pure returns (uint256) {
-        uint256 _number;
-
-        for (uint i = 0; i < 4; i++) {
             _number = _number + uint8(_b[i]) * (2 ** (8 * (_b.length - (i + 1))));
         }
 
@@ -271,6 +284,12 @@ library BTCUtils {
         return extractScriptSigLenAt(_input, 0);
     }
 
+    /// @notice          Determines the length of a scriptSig in an input
+    ///                  starting at the specified position
+    /// @dev             Will return 0 if passed a witness input.
+    /// @param _input    The byte array containing the LEGACY input
+    /// @param _at       The position of the input in the array
+    /// @return          The length of the script sig
     function extractScriptSigLenAt(bytes memory _input, uint256 _at) internal pure returns (uint256, uint256) {
         if (_input.length < 37 + _at) {
             return (ERR_BAD_ARG, 0);
@@ -291,6 +310,12 @@ library BTCUtils {
         return determineInputLengthAt(_input, 0);
     }
 
+    /// @notice          Determines the length of an input from its scriptSig,
+    ///                  starting at the specified position
+    /// @dev             36 for outpoint, 1 for scriptSig length, 4 for sequence
+    /// @param _input    The byte array containing the input
+    /// @param _at       The position of the input in the array
+    /// @return          The length of the input in bytes
     function determineInputLengthAt(bytes memory _input, uint256 _at) internal pure returns (uint256) {
         uint256 _varIntDataLen;
         uint256 _scriptSigLen;
@@ -374,6 +399,12 @@ library BTCUtils {
         return _input.slice32(0);
     }
 
+    /// @notice          Extracts the outpoint tx id from an input
+    ///                  starting at the specified position
+    /// @dev             32-byte tx id
+    /// @param _input    The byte array containing the input
+    /// @param _at       The position of the input
+    /// @return          The tx id (little-endian bytes)
     function extractInputTxIdLeAt(bytes memory _input, uint256 _at) internal pure returns (bytes32) {
         return _input.slice32(_at);
     }
@@ -386,6 +417,12 @@ library BTCUtils {
         return _input.slice4(32);
     }
 
+    /// @notice          Extracts the LE tx input index from the input in a tx
+    ///                  starting at the specified position
+    /// @dev             4-byte tx index
+    /// @param _input    The byte array containing the input
+    /// @param _at       The position of the input
+    /// @return          The tx index (little-endian bytes)
     function extractTxIndexLeAt(bytes memory _input, uint256 _at) internal pure returns (bytes4) {
         return _input.slice4(32 + _at);
     }
@@ -402,6 +439,12 @@ library BTCUtils {
         return determineOutputLengthAt(_output, 0);
     }
 
+    /// @notice          Determines the length of an output
+    ///                  starting at the specified position
+    /// @dev             Works with any properly formatted output
+    /// @param _output   The byte array containing the output
+    /// @param _at       The position of the output
+    /// @return          The length indicated by the prefix, error if invalid length
     function determineOutputLengthAt(bytes memory _output, uint256 _at) internal pure returns (uint256) {
         if (_output.length < 9 + _at) {
             return ERR_BAD_ARG;
@@ -683,6 +726,10 @@ library BTCUtils {
         return hash256(abi.encodePacked(_a, _b));
     }
 
+    /// @notice          Concatenates and hashes two inputs for merkle proving
+    /// @param _a        The first hash
+    /// @param _b        The second hash
+    /// @return          The double-sha256 of the concatenated hashes
     function _hash256MerkleStep(bytes32 _a, bytes32 _b) internal view returns (bytes32) {
         return hash256Pair(_a, _b);
     }

--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -632,6 +632,11 @@ library BTCUtils {
         return hash256(abi.encodePacked(_a, _b));
     }
 
+    function _hash256MerkleStep(bytes32 _a, bytes32 _b) internal pure returns (bytes32) {
+        return hash256(abi.encodePacked(_a, _b));
+    }
+
+
     /// @notice          Verifies a Bitcoin-style merkle tree
     /// @dev             Leaves are 0-indexed.
     /// @param _proof    The proof. Tightly packed LE sha256 hashes. The last hash is the root
@@ -659,9 +664,9 @@ library BTCUtils {
 
         for (uint i = 1; i < (_proof.length.div(32)) - 1; i++) {
             if (_idx % 2 == 1) {
-                _current = _hash256MerkleStep(_proof.slice(i * 32, 32), abi.encodePacked(_current));
+                _current = _hash256MerkleStep(_proof.slice32(i * 32), _current);
             } else {
-                _current = _hash256MerkleStep(abi.encodePacked(_current), _proof.slice(i * 32, 32));
+                _current = _hash256MerkleStep(_current, _proof.slice32(i * 32));
             }
             _idx = _idx >> 1;
         }

--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -27,13 +27,17 @@ library BTCUtils {
     /// @param _flag    The first byte of a VarInt
     /// @return         The number of non-flag bytes in the VarInt
     function determineVarIntDataLength(bytes memory _flag) internal pure returns (uint8) {
-        if (uint8(_flag[0]) == 0xff) {
+        return determineVarIntDataLengthAt(_flag, 0);
+    }
+
+    function determineVarIntDataLengthAt(bytes memory _b, uint256 _at) internal pure returns (uint8) {
+        if (uint8(_b[_at]) == 0xff) {
             return 8;  // one-byte flag, 8 bytes data
         }
-        if (uint8(_flag[0]) == 0xfe) {
+        if (uint8(_b[_at]) == 0xfe) {
             return 4;  // one-byte flag, 4 bytes data
         }
-        if (uint8(_flag[0]) == 0xfd) {
+        if (uint8(_b[_at]) == 0xfd) {
             return 2;  // one-byte flag, 2 bytes data
         }
 
@@ -46,15 +50,19 @@ library BTCUtils {
     /// @param _b   A byte-string starting with a VarInt
     /// @return     number of bytes in the encoding (not counting the tag), the encoded int
     function parseVarInt(bytes memory _b) internal pure returns (uint256, uint256) {
-        uint8 _dataLen = determineVarIntDataLength(_b);
+        return parseVarIntAt(_b, 0);
+    }
+
+    function parseVarIntAt(bytes memory _b, uint256 _at) internal pure returns (uint256, uint256) {
+        uint8 _dataLen = determineVarIntDataLengthAt(_b, _at);
 
         if (_dataLen == 0) {
-            return (0, uint8(_b[0]));
+            return (0, uint8(_b[_at]));
         }
-        if (_b.length < 1 + _dataLen) {
+        if (_b.length < 1 + _dataLen + _at) {
             return (ERR_BAD_ARG, 0);
         }
-        uint256 _number = bytesToUint(reverseEndianness(_b.slice(1, _dataLen)));
+        uint256 _number = bytesToUint(reverseEndianness(_b.slice(1 + _at, _dataLen)));
         return (_dataLen, _number);
     }
 

--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -62,7 +62,14 @@ library BTCUtils {
         if (_b.length < 1 + _dataLen + _at) {
             return (ERR_BAD_ARG, 0);
         }
-        uint256 _number = bytesToUint(reverseEndianness(_b.slice(1 + _at, _dataLen)));
+        uint256 _number;
+        if (_dataLen == 2) {
+            _number = reverseUint16(uint16(_b.slice2(1 + _at)));
+        } else if (_dataLen == 4) {
+            _number = reverseUint32(uint32(_b.slice4(1 + _at)));
+        } else if (_dataLen == 8) {
+            _number = reverseUint64(uint64(_b.slice8(1 + _at)));
+        }
         return (_dataLen, _number);
     }
 
@@ -129,6 +136,11 @@ library BTCUtils {
     function reverseUint24(uint24 _b) internal pure returns (uint24 v) {
         v =  (_b << 16) | (_b & 0x00FF00) | (_b >> 16);
     }
+
+    function reverseUint16(uint16 _b) internal pure returns (uint16 v) {
+        v =  (_b << 8) | (_b >> 8);
+    }
+
 
     /// @notice          Converts big-endian bytes to a uint
     /// @dev             Traverses the byte array and sums the bytes

--- a/solidity/contracts/BTCUtilsDelegate.sol
+++ b/solidity/contracts/BTCUtilsDelegate.sol
@@ -333,7 +333,7 @@ library BTCUtilsDelegate {
     /// @param _proof    The proof. Tightly packed LE sha256 hashes. The last hash is the root
     /// @param _index    The index of the leaf
     /// @return          true if the proof is valid, else false
-    function verifyHash256Merkle(bytes memory _proof, uint _index) public pure returns (bool) {
+    function verifyHash256Merkle(bytes memory _proof, uint _index) public view returns (bool) {
         return BTCUtils.verifyHash256Merkle(_proof, _index);
     }
 

--- a/solidity/contracts/BTCUtilsDelegate.sol
+++ b/solidity/contracts/BTCUtilsDelegate.sol
@@ -109,7 +109,7 @@ library BTCUtilsDelegate {
     /// @dev             Sequence is used for relative time locks
     /// @param _input    The LEGACY input
     /// @return          The sequence bytes (LE uint)
-    function extractSequenceLELegacy(bytes memory _input) public pure returns (bytes memory) {
+    function extractSequenceLELegacy(bytes memory _input) public pure returns (bytes4) {
         return BTCUtils.extractSequenceLELegacy(_input);
     }
 
@@ -145,7 +145,7 @@ library BTCUtilsDelegate {
     /// @dev             Sequence is used for relative time locks
     /// @param _input    The WITNESS input
     /// @return          The sequence bytes (LE uint)
-    function extractSequenceLEWitness(bytes memory _input) public pure returns (bytes memory) {
+    function extractSequenceLEWitness(bytes memory _input) public pure returns (bytes4) {
         return BTCUtils.extractSequenceLEWitness(_input);
     }
 
@@ -179,7 +179,7 @@ library BTCUtilsDelegate {
     /// @dev             4 byte tx index
     /// @param _input    The input
     /// @return          The tx index (little-endian bytes)
-    function extractTxIndexLE(bytes memory _input) public pure returns (bytes memory) {
+    function extractTxIndexLE(bytes memory _input) public pure returns (bytes4) {
         return BTCUtils.extractTxIndexLE(_input);
     }
 
@@ -208,7 +208,7 @@ library BTCUtilsDelegate {
     /// @dev             Value is an 8-byte little-endian number
     /// @param _output   The output
     /// @return          The output value as LE bytes
-    function extractValueLE(bytes memory _output) public pure returns (bytes memory) {
+    function extractValueLE(bytes memory _output) public pure returns (bytes8) {
         return BTCUtils.extractValueLE(_output);
     }
 
@@ -267,7 +267,7 @@ library BTCUtilsDelegate {
     /// @dev             Use verifyHash256Merkle to verify proofs with this root
     /// @param _header   The header
     /// @return          The merkle root (little-endian)
-    function extractMerkleRootLE(bytes memory _header) public pure returns (bytes memory) {
+    function extractMerkleRootLE(bytes memory _header) public pure returns (bytes32) {
         return BTCUtils.extractMerkleRootLE(_header);
     }
 
@@ -292,7 +292,7 @@ library BTCUtilsDelegate {
     /// @dev             Block headers do NOT include block number :(
     /// @param _header   The header
     /// @return          The previous block's hash (little-endian)
-    function extractPrevBlockLE(bytes memory _header) public pure returns (bytes memory) {
+    function extractPrevBlockLE(bytes memory _header) public pure returns (bytes32) {
         return BTCUtils.extractPrevBlockLE(_header);
     }
 
@@ -300,7 +300,7 @@ library BTCUtilsDelegate {
     /// @dev             Time is not 100% reliable
     /// @param _header   The header
     /// @return          The timestamp (little-endian bytes)
-    function extractTimestampLE(bytes memory _header) public pure returns (bytes memory) {
+    function extractTimestampLE(bytes memory _header) public pure returns (bytes4) {
         return BTCUtils.extractTimestampLE(_header);
     }
 

--- a/solidity/contracts/BytesLib.sol
+++ b/solidity/contracts/BytesLib.sol
@@ -300,28 +300,34 @@ library BytesLib {
     }
 
     // Static slice functions, no bounds checking
+    /// @notice take a 32-byte slice from the specified position
     function slice32(bytes memory _bytes, uint _start) internal pure returns (bytes32 res) {
         assembly {
             res := mload(add(add(_bytes, 32), _start))
         }
     }
 
+    /// @notice take a 20-byte slice from the specified position
     function slice20(bytes memory _bytes, uint _start) internal pure returns (bytes20) {
         return bytes20(slice32(_bytes, _start));
     }
 
+    /// @notice take a 8-byte slice from the specified position
     function slice8(bytes memory _bytes, uint _start) internal pure returns (bytes8) {
         return bytes8(slice32(_bytes, _start));
     }
 
+    /// @notice take a 4-byte slice from the specified position
     function slice4(bytes memory _bytes, uint _start) internal pure returns (bytes4) {
         return bytes4(slice32(_bytes, _start));
     }
 
+    /// @notice take a 3-byte slice from the specified position
     function slice3(bytes memory _bytes, uint _start) internal pure returns (bytes3) {
         return bytes3(slice32(_bytes, _start));
     }
 
+    /// @notice take a 2-byte slice from the specified position
     function slice2(bytes memory _bytes, uint _start) internal pure returns (bytes2) {
         return bytes2(slice32(_bytes, _start));
     }

--- a/solidity/contracts/BytesLib.sol
+++ b/solidity/contracts/BytesLib.sol
@@ -270,6 +270,24 @@ library BytesLib {
         }
     }
 
+    function slice32(bytes memory _bytes, uint _start) internal pure returns (bytes32 res) {
+        assembly {
+            res := mload(add(add(_bytes, 32), _start))
+        }
+    }
+
+    function slice20(bytes memory _bytes, uint _start) internal pure returns (bytes20) {
+        return bytes20(slice32(_bytes, _start));
+    }
+
+    function slice8(bytes memory _bytes, uint _start) internal pure returns (bytes8) {
+        return bytes8(slice32(_bytes, _start));
+    }
+
+    function slice4(bytes memory _bytes, uint _start) internal pure returns (bytes4) {
+        return bytes4(slice32(_bytes, _start));
+    }
+
     function toAddress(bytes memory _bytes, uint _start) internal  pure returns (address) {
         uint _totalLen = _start + 20;
         require(_totalLen > _start && _bytes.length >= _totalLen, "Address conversion out of bounds.");

--- a/solidity/contracts/BytesLib.sol
+++ b/solidity/contracts/BytesLib.sol
@@ -322,6 +322,10 @@ library BytesLib {
         return bytes3(slice32(_bytes, _start));
     }
 
+    function slice2(bytes memory _bytes, uint _start) internal pure returns (bytes2) {
+        return bytes2(slice32(_bytes, _start));
+    }
+
     function toAddress(bytes memory _bytes, uint _start) internal  pure returns (address) {
         uint _totalLen = _start + 20;
         require(_totalLen > _start && _bytes.length >= _totalLen, "Address conversion out of bounds.");

--- a/solidity/contracts/BytesLib.sol
+++ b/solidity/contracts/BytesLib.sol
@@ -288,6 +288,10 @@ library BytesLib {
         return bytes4(slice32(_bytes, _start));
     }
 
+    function slice3(bytes memory _bytes, uint _start) internal pure returns (bytes3) {
+        return bytes3(slice32(_bytes, _start));
+    }
+
     function toAddress(bytes memory _bytes, uint _start) internal  pure returns (address) {
         uint _totalLen = _start + 20;
         require(_totalLen > _start && _bytes.length >= _totalLen, "Address conversion out of bounds.");

--- a/solidity/contracts/BytesLib.sol
+++ b/solidity/contracts/BytesLib.sol
@@ -270,6 +270,36 @@ library BytesLib {
         }
     }
 
+    /// @notice Take a slice of the byte array, overwriting the destination.
+    /// The length of the slice will equal the length of the destination array.
+    /// @dev Make sure the destination array has afterspace if required.
+    /// @param _bytes The source array
+    /// @param _dest The destination array.
+    /// @param _start The location to start in the source array.
+    function sliceInPlace(
+        bytes memory _bytes,
+        bytes memory _dest,
+        uint _start
+    ) internal pure {
+        uint _length = _dest.length;
+        uint _end = _start + _length;
+        require(_end > _start && _bytes.length >= _end, "Slice out of bounds");
+
+        assembly {
+            for {
+                let src := add(add(_bytes, 32), _start)
+                let res := add(_dest, 32)
+                let end := add(src, _length)
+            } lt(src, end) {
+                src := add(src, 32)
+                res := add(res, 32)
+            } {
+                mstore(res, mload(src))
+            }
+        }
+    }
+
+    // Static slice functions, no bounds checking
     function slice32(bytes memory _bytes, uint _start) internal pure returns (bytes32 res) {
         assembly {
             res := mload(add(add(_bytes, 32), _start))

--- a/solidity/contracts/CheckBitcoinSigs.sol
+++ b/solidity/contracts/CheckBitcoinSigs.sol
@@ -133,7 +133,7 @@ library CheckBitcoinSigs {
         bytes8 _inputValue,      // 8-byte LE
         bytes8 _outputValue,     // 8-byte LE
         bytes memory _outputScript    // lenght-prefixed output script
-    ) internal pure returns (bytes32) {
+    ) internal view returns (bytes32) {
         // Fixes elements to easily make a 1-in 1-out sighash digest
         // Does not support timelocks
         bytes memory _scriptCode = abi.encodePacked(
@@ -142,10 +142,10 @@ library CheckBitcoinSigs {
             hex"88ac");  // equal, checksig
         bytes32 _hashOutputs = abi.encodePacked(
             _outputValue,  // 8-byte LE
-            _outputScript).hash256();
+            _outputScript).hash256View();
         bytes memory _sighashPreimage = abi.encodePacked(
             hex"01000000",  // version
-            _outpoint.hash256(),  // hashPrevouts
+            _outpoint.hash256View(),  // hashPrevouts
             hex"8cb9012517c817fead650287d61bdd9c68803b6bf9c64133dcab3e65b5a50cb9",  // hashSequence(00000000)
             _outpoint,  // outpoint
             _scriptCode,  // p2wpkh script code
@@ -155,7 +155,7 @@ library CheckBitcoinSigs {
             hex"00000000",  // nLockTime
             hex"01000000"  // SIGHASH_ALL
         );
-        return _sighashPreimage.hash256();
+        return _sighashPreimage.hash256View();
     }
 
     /// @notice                 calculates the signature hash of a Bitcoin transaction with the provided details

--- a/solidity/contracts/CheckBitcoinSigs.sol
+++ b/solidity/contracts/CheckBitcoinSigs.sol
@@ -34,10 +34,10 @@ library CheckBitcoinSigs {
 
         if (_pubkey.length == 64) {
             _prefix = uint8(_pubkey[_pubkey.length - 1]) % 2 == 1 ? 3 : 2;
-            _compressedPubkey = abi.encodePacked(_prefix, _pubkey.slice(0, 32));
+            _compressedPubkey = abi.encodePacked(_prefix, _pubkey.slice32(0));
         } else if (_pubkey.length == 65) {
             _prefix = uint8(_pubkey[_pubkey.length - 1]) % 2 == 1 ? 3 : 2;
-            _compressedPubkey = abi.encodePacked(_prefix, _pubkey.slice(1, 32));
+            _compressedPubkey = abi.encodePacked(_prefix, _pubkey.slice32(1));
         } else {
             _compressedPubkey = _pubkey;
         }

--- a/solidity/contracts/ValidateSPV.sol
+++ b/solidity/contracts/ValidateSPV.sol
@@ -52,9 +52,13 @@ library ValidateSPV {
             return true;
         }
 
-        bytes memory _proof = abi.encodePacked(_txid, _intermediateNodes, _merkleRoot);
         // If the Merkle proof failed, bubble up error
-        return _proof.verifyHash256Merkle(_index);
+        return verifyHash256Merkle(
+            _txid,
+            _intermediateNodes,
+            _merkleRoot,
+            _index
+        );
     }
 
     /// @notice             Hashes transaction to get txid
@@ -69,9 +73,9 @@ library ValidateSPV {
         bytes memory _vin,
         bytes memory _vout,
         bytes memory _locktime
-    ) internal pure returns (bytes32) {
+    ) internal view returns (bytes32) {
         // Get transaction hash double-Sha256(version + nIns + inputs + nOuts + outputs + locktime)
-        return abi.encodePacked(_version, _vin, _vout, _locktime).hash256();
+        return abi.encodePacked(_version, _vin, _vout, _locktime).hash256View();
     }
 
     /// @notice                  Checks validity of header chain

--- a/solidity/contracts/ValidateSPV.sol
+++ b/solidity/contracts/ValidateSPV.sol
@@ -46,7 +46,7 @@ library ValidateSPV {
         bytes32 _merkleRoot,
         bytes memory _intermediateNodes,
         uint _index
-    ) internal pure returns (bool) {
+    ) internal view returns (bool) {
         // Shortcut the empty-block case
         if (_txid == _merkleRoot && _index == 0 && _intermediateNodes.length == 0) {
             return true;

--- a/solidity/contracts/ValidateSPV.sol
+++ b/solidity/contracts/ValidateSPV.sol
@@ -88,10 +88,19 @@ library ValidateSPV {
 
         _totalDifficulty = 0;
 
+        bytes memory _header;
+
+        // Allocate _header with extra space after it to fit 3 full words
+        assembly {
+            _header := mload(0x40)
+            mstore(0x40, add(_header, add(32, 96)))
+            mstore(_header, 80)
+        }
+
         for (uint256 _start = 0; _start < _headers.length; _start += 80) {
 
             // ith header start index and ith header
-            bytes memory _header = _headers.slice(_start, 80);
+            _headers.sliceInPlace(_header, _start);
 
             // After the first header, check that headers are in a chain
             if (_start != 0) {

--- a/solidity/contracts/ValidateSPV.sol
+++ b/solidity/contracts/ValidateSPV.sol
@@ -129,7 +129,7 @@ library ValidateSPV {
     function validateHeaderPrevHash(bytes memory _header, bytes32 _prevHeaderDigest) internal pure returns (bool) {
 
         // Extract prevHash of current header
-        bytes32 _prevHash = _header.extractPrevBlockLE().toBytes32();
+        bytes32 _prevHash = _header.extractPrevBlockLE();
 
         // Compare prevHash of current header to previous header's digest
         if (_prevHash != _prevHeaderDigest) {return false;}

--- a/solidity/contracts/ValidateSPV.sol
+++ b/solidity/contracts/ValidateSPV.sol
@@ -127,7 +127,7 @@ library ValidateSPV {
     /// @return             true if header work is valid, false otherwise
     function validateHeaderWork(bytes32 _digest, uint256 _target) internal pure returns (bool) {
         if (_digest == bytes32(0)) {return false;}
-        return (abi.encodePacked(_digest).reverseEndianness().bytesToUint() < _target);
+        return (uint256(_digest).reverseUint256() < _target);
     }
 
     /// @notice                     Checks validity of header chain

--- a/solidity/contracts/ValidateSPV.sol
+++ b/solidity/contracts/ValidateSPV.sol
@@ -66,13 +66,13 @@ library ValidateSPV {
     /// @param _version     4-bytes version
     /// @param _vin         Raw bytes length-prefixed input vector
     /// @param _vout        Raw bytes length-prefixed output vector
-    /// @param _locktime   4-byte tx locktime
+    /// @param _locktime    4-byte tx locktime
     /// @return             32-byte transaction id, little endian
     function calculateTxId(
-        bytes memory _version,
+        bytes4 _version,
         bytes memory _vin,
         bytes memory _vout,
-        bytes memory _locktime
+        bytes4 _locktime
     ) internal view returns (bytes32) {
         // Get transaction hash double-Sha256(version + nIns + inputs + nOuts + outputs + locktime)
         return abi.encodePacked(_version, _vin, _vout, _locktime).hash256View();

--- a/solidity/contracts/ValidateSPVDelegate.sol
+++ b/solidity/contracts/ValidateSPVDelegate.sol
@@ -31,7 +31,7 @@ library ValidateSPVDelegate {
         bytes32 _merkleRoot,
         bytes memory _proof,
         uint _index
-    ) public pure returns (bool) {
+    ) public view returns (bool) {
         return ValidateSPV.prove(_txid, _merkleRoot, _proof, _index);
     }
 

--- a/solidity/contracts/ValidateSPVDelegate.sol
+++ b/solidity/contracts/ValidateSPVDelegate.sol
@@ -43,10 +43,10 @@ library ValidateSPVDelegate {
     /// @ param _locktime   4-byte tx locktime
     /// @return             32-byte transaction id, little endian
     function calculateTxId(
-        bytes memory _version,
+        bytes4 _version,
         bytes memory _vin,
         bytes memory _vout,
-        bytes memory _locktime
+        bytes4 _locktime
     ) public view returns (bytes32) {
         return ValidateSPV.calculateTxId(_version, _vin, _vout, _locktime);
     }

--- a/solidity/contracts/ValidateSPVDelegate.sol
+++ b/solidity/contracts/ValidateSPVDelegate.sol
@@ -47,7 +47,7 @@ library ValidateSPVDelegate {
         bytes memory _vin,
         bytes memory _vout,
         bytes memory _locktime
-    ) public pure returns (bytes32) {
+    ) public view returns (bytes32) {
         return ValidateSPV.calculateTxId(_version, _vin, _vout, _locktime);
     }
 

--- a/solidity/contracts/test/BTCUtilsTest.sol
+++ b/solidity/contracts/test/BTCUtilsTest.sol
@@ -102,7 +102,7 @@ contract BTCUtilsTest {
     /// @dev             Sequence is used for relative time locks
     /// @param _input    The LEGACY input
     /// @return          The sequence bytes (LE uint)
-    function extractSequenceLELegacy(bytes memory _input) public pure returns (bytes memory) {
+    function extractSequenceLELegacy(bytes memory _input) public pure returns (bytes4) {
         return BTCUtils.extractSequenceLELegacy(_input);
     }
 
@@ -138,7 +138,7 @@ contract BTCUtilsTest {
     /// @dev             Sequence is used for relative time locks
     /// @param _input    The WITNESS input
     /// @return          The sequence bytes (LE uint)
-    function extractSequenceLEWitness(bytes memory _input) public pure returns (bytes memory) {
+    function extractSequenceLEWitness(bytes memory _input) public pure returns (bytes4) {
         return BTCUtils.extractSequenceLEWitness(_input);
     }
 
@@ -172,7 +172,7 @@ contract BTCUtilsTest {
     /// @dev             4 byte tx index
     /// @param _input    The input
     /// @return          The tx index (little-endian bytes)
-    function extractTxIndexLE(bytes memory _input) public pure returns (bytes memory) {
+    function extractTxIndexLE(bytes memory _input) public pure returns (bytes4) {
         return BTCUtils.extractTxIndexLE(_input);
     }
 
@@ -202,7 +202,7 @@ contract BTCUtilsTest {
     /// @dev             Value is an 8-byte little-endian number
     /// @param _output   The output
     /// @return          The output value as LE bytes
-    function extractValueLE(bytes memory _output) public pure returns (bytes memory) {
+    function extractValueLE(bytes memory _output) public pure returns (bytes8) {
         return BTCUtils.extractValueLE(_output);
     }
 
@@ -261,7 +261,7 @@ contract BTCUtilsTest {
     /// @dev             Use verifyHash256Merkle to verify proofs with this root
     /// @param _header   The header
     /// @return          The merkle root (little-endian)
-    function extractMerkleRootLE(bytes memory _header) public pure returns (bytes memory) {
+    function extractMerkleRootLE(bytes memory _header) public pure returns (bytes32) {
         return BTCUtils.extractMerkleRootLE(_header);
     }
 
@@ -286,7 +286,7 @@ contract BTCUtilsTest {
     /// @dev             Block headers do NOT include block number :(
     /// @param _header   The header
     /// @return          The previous block's hash (little-endian)
-    function extractPrevBlockLE(bytes memory _header) public pure returns (bytes memory) {
+    function extractPrevBlockLE(bytes memory _header) public pure returns (bytes32) {
         return BTCUtils.extractPrevBlockLE(_header);
     }
 
@@ -294,7 +294,7 @@ contract BTCUtilsTest {
     /// @dev             Time is not 100% reliable
     /// @param _header   The header
     /// @return          The timestamp (little-endian bytes)
-    function extractTimestampLE(bytes memory _header) public pure returns (bytes memory) {
+    function extractTimestampLE(bytes memory _header) public pure returns (bytes4) {
         return BTCUtils.extractTimestampLE(_header);
     }
 

--- a/solidity/contracts/test/BTCUtilsTest.sol
+++ b/solidity/contracts/test/BTCUtilsTest.sol
@@ -327,7 +327,7 @@ contract BTCUtilsTest {
     /// @param _proof    The proof. Tightly packed LE sha256 hashes. The last hash is the root
     /// @param _index    The index of the leaf
     /// @return          true if the proof is valid, else false
-    function verifyHash256Merkle(bytes memory _proof, uint _index) public pure returns (bool) {
+    function verifyHash256Merkle(bytes memory _proof, uint _index) public view returns (bool) {
         return BTCUtils.verifyHash256Merkle(_proof, _index);
     }
 

--- a/solidity/contracts/test/ValidateSPVTest.sol
+++ b/solidity/contracts/test/ValidateSPVTest.sol
@@ -46,7 +46,7 @@ contract ValidateSPVTest {
         bytes memory _vin,
         bytes memory _vout,
         bytes memory _locktime
-    ) public pure returns (bytes32) {
+    ) public view returns (bytes32) {
         return ValidateSPV.calculateTxId(_version, _vin, _vout, _locktime);
     }
 

--- a/solidity/contracts/test/ValidateSPVTest.sol
+++ b/solidity/contracts/test/ValidateSPVTest.sol
@@ -42,10 +42,10 @@ contract ValidateSPVTest {
     /// @ param _locktime   4-byte tx locktime
     /// @return             32-byte transaction id, little endian
     function calculateTxId(
-        bytes memory _version,
+        bytes4 _version,
         bytes memory _vin,
         bytes memory _vout,
-        bytes memory _locktime
+        bytes4 _locktime
     ) public view returns (bytes32) {
         return ValidateSPV.calculateTxId(_version, _vin, _vout, _locktime);
     }

--- a/solidity/contracts/test/ValidateSPVTest.sol
+++ b/solidity/contracts/test/ValidateSPVTest.sol
@@ -30,7 +30,7 @@ contract ValidateSPVTest {
         bytes32 _merkleRoot,
         bytes memory _proof,
         uint _index
-    ) public pure returns (bool) {
+    ) public view returns (bool) {
         return ValidateSPV.prove(_txid, _merkleRoot, _proof, _index);
     }
 

--- a/solidity/test/BTCUtils.test.js
+++ b/solidity/test/BTCUtils.test.js
@@ -371,7 +371,10 @@ contract('BTCUtils', () => {
   it('extracts a timestamp from a header', async () => {
     for (let i = 0; i < extractTimestamp.length; i += 1) {
       const res = await instance.extractTimestamp(extractTimestamp[i].input);
-      assert(res.eq(new BN(extractTimestamp[i].output, 10)));
+      assert.equal(
+        res.toNumber(),
+        extractTimestamp[i].output
+      );
     }
   });
 


### PR DESCRIPTION
Currently the code causes a large number of unnecessary allocations because everything is handled as `bytes`. Replacing `bytes` with static `bytesX` where possible helps remove allocations and reduce code complexity. Other optimisations may follow.