### PR TITLE
Add workflows for running tests and publishing NPM package

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -54,27 +54,3 @@ jobs:
 
       - name: Run tests
         run: npm run test
-
-  contracts-lint:
-    needs: contracts-detect-changes
-    if: |
-      github.event_name == 'push'
-        || needs.contracts-detect-changes.outputs.path-filter == 'true'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./solidity
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "14.x"
-          cache: "npm"
-          cache-dependency-path: solidity/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint
-        run: npm run lint

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,80 @@
+name: Solidity
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+    branches:
+      - releases/mainnet/solidity/**
+    paths:
+      - "solidity/**"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  contracts-detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      path-filter: ${{ steps.filter.outputs.path-filter }}
+    steps:
+      - uses: actions/checkout@v2
+        if: github.event_name == 'pull_request'
+
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            path-filter:
+              - './solidity/**'
+
+  contracts-build-and-test:
+    needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+          cache: "npm"
+          cache-dependency-path: solidity/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build contracts
+        run: npm run compile
+
+      - name: Run tests
+        run: npm run test
+
+  contracts-lint:
+    needs: contracts-detect-changes
+    if: |
+      github.event_name == 'push'
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          cache: "npm"
+          cache-dependency-path: solidity/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,30 @@
+name: NPM
+
+on:
+  push:
+    branches:
+      - releases/mainnet/solidity/**
+    paths:
+      - "solidity/package.json"
+  workflow_dispatch:
+
+jobs:
+  npm-publish-contracts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          cache: "npm"
+          cache-dependency-path: solidity/package-lock.json
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@summa-tx/bitcoin-spv-sol",
-  "version": "3.1.0",
+  "name": "@keep-network/bitcoin-spv-sol",
+  "version": "v3.1.0-solc-0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -2,6 +2,10 @@
   "name": "@keep-network/bitcoin-spv-sol",
   "version": "v3.1.0-solc-0.8",
   "description": "bitcoin SPV proofs in Solidity",
+  "files": [
+    "contracts/**/*.sol",
+    "migrations/scripts"
+  ],
   "scripts": {
     "compile": "truffle compile",
     "test": "cp ../testVectors.json test/ && truffle test",


### PR DESCRIPTION
Adding GH Actions workflow that compiles contracts and runs unit tests.
Workflow will be executed every time a PR is created or there's a change
merged to `main` branch. It will also execute every night at midnight
and every time someone dispatches it manually.
Also adding a workflow which will publish a package to NPM registry.
Workflow will execute every time a change in the `solidity/package.json`
file is pushed to a branch which name starts with
`releases/mainnet/solidity/` (or when someone dispatches workflow
manually). Published package will be versioned exactly as it is secfied
in the `package.json` file. The publish will fail if the package name
and version combination already exists in the NPM registry.