### PR TITLE
Minor optimisations and gas cost reporting

### DIFF
--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -197,6 +197,20 @@ library BTCUtils {
         return abi.encodePacked(ripemd160(abi.encodePacked(sha256(_b))));
     }
 
+    /// @notice          Implements bitcoin's hash160 (sha2 + ripemd160)
+    /// @dev             sha2 precompile at address(2), ripemd160 at address(3)
+    /// @param _b        The pre-image
+    /// @return res      The digest
+    function hash160View(bytes memory _b) internal view returns (bytes20 res) {
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            pop(staticcall(gas(), 2, add(_b, 32), mload(_b), 0x00, 32))
+            pop(staticcall(gas(), 3, 0x00, 32, 0x00, 32))
+            // read from position 12 = 0c
+            res := mload(0x0c)
+        }
+    }
+
     /// @notice          Implements bitcoin's hash256 (double sha2)
     /// @dev             abi.encodePacked changes the return to bytes instead of bytes32
     /// @param _b        The pre-image

--- a/solidity/contracts/BTCUtils.sol
+++ b/solidity/contracts/BTCUtils.sol
@@ -284,7 +284,7 @@ library BTCUtils {
     /// @param _input    The input
     /// @return          True for legacy, False for witness
     function isLegacyInput(bytes memory _input) internal pure returns (bool) {
-        return _input.keccak256Slice(36, 1) != keccak256(hex"00");
+        return _input[36] != hex"00";
     }
 
     /// @notice          Determines the length of a scriptSig in an input
@@ -522,7 +522,7 @@ library BTCUtils {
     /// @param _output   The output
     /// @return          Any data contained in the opreturn output, null if not an op return
     function extractOpReturnData(bytes memory _output) internal pure returns (bytes memory) {
-        if (_output.keccak256Slice(9, 1) != keccak256(hex"6a")) {
+        if (_output[9] != hex"6a") {
             return hex"";
         }
         bytes1 _dataLen = _output[10];
@@ -556,18 +556,18 @@ library BTCUtils {
             }
             return _output.slice(11, _payloadLen);
         } else {
-            bytes32 _tag = _output.keccak256Slice(8, 3);
+            bytes3 _tag = _output.slice3(8);
             // p2pkh
-            if (_tag == keccak256(hex"1976a9")) {
+            if (_tag == hex"1976a9") {
                 // Check for maliciously formatted p2pkh
                 // No need to worry about underflow, b/c of _scriptLen check
                 if (uint8(_output[11]) != 0x14 ||
-                    _output.keccak256Slice(_output.length - 2, 2) != keccak256(hex"88ac")) {
+                    _output.slice2(_output.length - 2) != hex"88ac") {
                     return hex"";
                 }
                 return _output.slice(12, 20);
             //p2sh
-            } else if (_tag == keccak256(hex"17a914")) {
+            } else if (_tag == hex"17a914") {
                 // Check for maliciously formatted p2sh
                 // No need to worry about underflow, b/c of _scriptLen check
                 if (uint8(_output[_output.length - 1]) != 0x87) {

--- a/solidity/contracts/CheckBitcoinSigsDelegate.sol
+++ b/solidity/contracts/CheckBitcoinSigsDelegate.sol
@@ -19,7 +19,7 @@ library CheckBitcoinSigsDelegate {
     /// @dev             Compresses keys to 33 bytes as required by Bitcoin
     /// @param _pubkey   The public key, compressed or uncompressed
     /// @return          The p2wkph output script
-    function p2wpkhFromPubkey(bytes memory _pubkey) public pure returns (bytes memory) {
+    function p2wpkhFromPubkey(bytes memory _pubkey) public view returns (bytes memory) {
         return CheckBitcoinSigs.p2wpkhFromPubkey(_pubkey);
     }
 
@@ -57,7 +57,7 @@ library CheckBitcoinSigsDelegate {
         uint8 _v,
         bytes32 _r,
         bytes32 _s
-    ) public pure returns (bool) {
+    ) public view returns (bool) {
         return CheckBitcoinSigs.checkBitcoinSig(
             _p2wpkhOutputScript,
             _pubkey,

--- a/solidity/contracts/test/BTCUtilsTest.sol
+++ b/solidity/contracts/test/BTCUtilsTest.sol
@@ -15,7 +15,7 @@ contract BTCUtilsTest {
     /// @dev            A VarInt of >1 byte is prefixed with a flag indicating its length
     /// @param _flag    The first byte of a VarInt
     /// @return         The number of non-flag bytes in the VarInt
-    function determineVarIntDataLength(bytes memory _flag) public pure returns (uint8) {
+    function determineVarIntDataLength(bytes memory _flag) public returns (uint8) {
         return BTCUtils.determineVarIntDataLength(_flag);
     }
 
@@ -24,7 +24,7 @@ contract BTCUtilsTest {
     ///             Caller SHOULD explicitly handle this case (or bubble it up)
     /// @param _b   A byte-string starting with a VarInt
     /// @return     number of bytes in the encoding (not counting the tag), the encoded int
-    function parseVarInt(bytes memory _b) public pure returns (uint256, uint256) {
+    function parseVarInt(bytes memory _b) public returns (uint256, uint256) {
         return BTCUtils.parseVarInt(_b);
     }
 
@@ -33,7 +33,7 @@ contract BTCUtilsTest {
     /// @dev             Returns a new, backwards, bytes
     /// @param _b        The bytes to reverse
     /// @return          The reversed bytes
-    function reverseEndianness(bytes memory _b) public pure returns (bytes memory) {
+    function reverseEndianness(bytes memory _b) public returns (bytes memory) {
         return BTCUtils.reverseEndianness(_b);
     }
 
@@ -41,7 +41,7 @@ contract BTCUtilsTest {
     /// @dev             Traverses the byte array and sums the bytes
     /// @param _b        The big-endian bytes-encoded integer
     /// @return          The integer representation
-    function bytesToUint(bytes memory _b) public pure returns (uint256) {
+    function bytesToUint(bytes memory _b) public returns (uint256) {
         return BTCUtils.bytesToUint(_b);
     }
 
@@ -49,7 +49,7 @@ contract BTCUtilsTest {
     /// @param _b        The byte array to slice
     /// @param _num      The number of bytes to extract from the end
     /// @return          The last _num bytes of _b
-    function lastBytes(bytes memory _b, uint256 _num) public pure returns (bytes memory) {
+    function lastBytes(bytes memory _b, uint256 _num) public returns (bytes memory) {
         return BTCUtils.lastBytes(_b, _num);
     }
 
@@ -57,7 +57,7 @@ contract BTCUtilsTest {
     /// @dev             abi.encodePacked changes the return to bytes instead of bytes32
     /// @param _b        The pre-image
     /// @return          The digest
-    function hash160(bytes memory _b) public pure returns (bytes memory) {
+    function hash160(bytes memory _b) public returns (bytes memory) {
         return BTCUtils.hash160(_b);
     }
 
@@ -65,7 +65,7 @@ contract BTCUtilsTest {
     /// @dev             abi.encodePacked changes the return to bytes instead of bytes32
     /// @param _b        The pre-image
     /// @return          The digest
-    function hash256(bytes memory _b) public pure returns (bytes32) {
+    function hash256(bytes memory _b) public returns (bytes32) {
         return BTCUtils.hash256(_b);
     }
 
@@ -78,7 +78,7 @@ contract BTCUtilsTest {
     /// @param _vin      The vin as a tightly-packed byte array
     /// @param _index    The 0-indexed location of the input to extract
     /// @return          The input as a byte array
-    function extractInputAtIndex(bytes memory _vin, uint256 _index) public pure returns (bytes memory) {
+    function extractInputAtIndex(bytes memory _vin, uint256 _index) public returns (bytes memory) {
         return BTCUtils.extractInputAtIndex(_vin, _index);
     }
 
@@ -86,7 +86,7 @@ contract BTCUtilsTest {
     /// @dev             False if no scriptSig, otherwise True
     /// @param _input    The input
     /// @return          True for legacy, False for witness
-    function isLegacyInput(bytes memory _input) public pure returns (bool) {
+    function isLegacyInput(bytes memory _input) public returns (bool) {
         return BTCUtils.isLegacyInput(_input);
     }
 
@@ -94,7 +94,7 @@ contract BTCUtilsTest {
     /// @dev             36 for outpoint, 1 for scriptsig length, 4 for sequence
     /// @param _input    The input
     /// @return          The length of the input in bytes
-    function determineInputLength(bytes memory _input) public pure returns (uint256) {
+    function determineInputLength(bytes memory _input) public returns (uint256) {
         return BTCUtils.determineInputLength(_input);
     }
 
@@ -102,7 +102,7 @@ contract BTCUtilsTest {
     /// @dev             Sequence is used for relative time locks
     /// @param _input    The LEGACY input
     /// @return          The sequence bytes (LE uint)
-    function extractSequenceLELegacy(bytes memory _input) public pure returns (bytes4) {
+    function extractSequenceLELegacy(bytes memory _input) public returns (bytes4) {
         return BTCUtils.extractSequenceLELegacy(_input);
     }
 
@@ -110,14 +110,14 @@ contract BTCUtilsTest {
     /// @dev             Sequence is a 4-byte little-endian number
     /// @param _input    The LEGACY input
     /// @return          The sequence number (big-endian uint)
-    function extractSequenceLegacy(bytes memory _input) public pure returns (uint32) {
+    function extractSequenceLegacy(bytes memory _input) public returns (uint32) {
         return BTCUtils.extractSequenceLegacy(_input);
     }
     /// @notice          Extracts the length-prepended scriptSig from the input in a tx
     /// @dev             Will return hex"00" if passed a witness input
     /// @param _input    The LEGACY input
     /// @return          The length-prepended script sig
-    function extractScriptSig(bytes memory _input) public pure returns (bytes memory) {
+    function extractScriptSig(bytes memory _input) public returns (bytes memory) {
         return BTCUtils.extractScriptSig(_input);
     }
 
@@ -125,7 +125,7 @@ contract BTCUtilsTest {
     /// @dev             Will return 0 if passed a witness input
     /// @param _input    The LEGACY input
     /// @return          The length of the script sig
-    function extractScriptSigLen(bytes memory _input) public pure returns (uint256, uint256) {
+    function extractScriptSigLen(bytes memory _input) public returns (uint256, uint256) {
         return BTCUtils.extractScriptSigLen(_input);
     }
 
@@ -138,7 +138,7 @@ contract BTCUtilsTest {
     /// @dev             Sequence is used for relative time locks
     /// @param _input    The WITNESS input
     /// @return          The sequence bytes (LE uint)
-    function extractSequenceLEWitness(bytes memory _input) public pure returns (bytes4) {
+    function extractSequenceLEWitness(bytes memory _input) public returns (bytes4) {
         return BTCUtils.extractSequenceLEWitness(_input);
     }
 
@@ -147,7 +147,7 @@ contract BTCUtilsTest {
     /// @dev             Sequence is a 4-byte little-endian number
     /// @param _input    The WITNESS input
     /// @return          The sequence number (big-endian uint)
-    function extractSequenceWitness(bytes memory _input) public pure returns (uint32) {
+    function extractSequenceWitness(bytes memory _input) public returns (uint32) {
         return BTCUtils.extractSequenceWitness(_input);
     }
 
@@ -155,7 +155,7 @@ contract BTCUtilsTest {
     /// @dev             32 byte tx id with 4 byte index
     /// @param _input    The input
     /// @return          The outpoint (LE bytes of prev tx hash + LE bytes of prev tx index)
-    function extractOutpoint(bytes memory _input) public pure returns (bytes memory) {
+    function extractOutpoint(bytes memory _input) public returns (bytes memory) {
         return BTCUtils.extractOutpoint(_input);
     }
 
@@ -164,7 +164,7 @@ contract BTCUtilsTest {
     /// @dev             32 byte tx id
     /// @param _input    The input
     /// @return          The tx id (little-endian bytes)
-    function extractInputTxIdLE(bytes memory _input) public pure returns (bytes32) {
+    function extractInputTxIdLE(bytes memory _input) public returns (bytes32) {
         return BTCUtils.extractInputTxIdLE(_input);
     }
 
@@ -172,7 +172,7 @@ contract BTCUtilsTest {
     /// @dev             4 byte tx index
     /// @param _input    The input
     /// @return          The tx index (little-endian bytes)
-    function extractTxIndexLE(bytes memory _input) public pure returns (bytes4) {
+    function extractTxIndexLE(bytes memory _input) public returns (bytes4) {
         return BTCUtils.extractTxIndexLE(_input);
     }
 
@@ -185,7 +185,7 @@ contract BTCUtilsTest {
     /// @dev             5 types: WPKH, WSH, PKH, SH, and OP_RETURN
     /// @param _output   The output
     /// @return          The length indicated by the prefix, error if invalid length
-    function determineOutputLength(bytes memory _output) public pure returns (uint256) {
+    function determineOutputLength(bytes memory _output) public returns (uint256) {
         return BTCUtils.determineOutputLength(_output);
     }
 
@@ -194,7 +194,7 @@ contract BTCUtilsTest {
     /// @param _vout     The _vout to extract from
     /// @param _index    The 0-indexed location of the output to extract
     /// @return          The specified output
-    function extractOutputAtIndex(bytes memory _vout, uint256 _index) public pure returns (bytes memory) {
+    function extractOutputAtIndex(bytes memory _vout, uint256 _index) public returns (bytes memory) {
         return BTCUtils.extractOutputAtIndex(_vout, _index);
     }
 
@@ -202,7 +202,7 @@ contract BTCUtilsTest {
     /// @dev             Value is an 8-byte little-endian number
     /// @param _output   The output
     /// @return          The output value as LE bytes
-    function extractValueLE(bytes memory _output) public pure returns (bytes8) {
+    function extractValueLE(bytes memory _output) public returns (bytes8) {
         return BTCUtils.extractValueLE(_output);
     }
 
@@ -210,7 +210,7 @@ contract BTCUtilsTest {
     /// @dev             Value is an 8-byte little-endian number
     /// @param _output   The output
     /// @return          The output value
-    function extractValue(bytes memory _output) public pure returns (uint64) {
+    function extractValue(bytes memory _output) public returns (uint64) {
         return BTCUtils.extractValue(_output);
     }
 
@@ -218,7 +218,7 @@ contract BTCUtilsTest {
     /// @dev             Returns hex"" if no data or not an op return
     /// @param _output   The output
     /// @return          Any data contained in the opreturn output, null if not an op return
-    function extractOpReturnData(bytes memory _output) public pure returns (bytes memory) {
+    function extractOpReturnData(bytes memory _output) public returns (bytes memory) {
         return BTCUtils.extractOpReturnData(_output);
     }
 
@@ -226,7 +226,7 @@ contract BTCUtilsTest {
     /// @dev             Determines type by the length prefix
     /// @param _output   The output
     /// @return          The hash committed to by the pk_script
-    function extractHash(bytes memory _output) public pure returns (bytes memory) {
+    function extractHash(bytes memory _output) public returns (bytes memory) {
         return BTCUtils.extractHash(_output);
     }
 
@@ -239,7 +239,7 @@ contract BTCUtilsTest {
     /// @dev         Consider a vin with a valid vout in its scriptsig
     /// @param _vin  Raw bytes length-prefixed input vector
     /// @return      True if it represents a validly formatted vin
-    function validateVin(bytes memory _vin) public pure returns (bool) {
+    function validateVin(bytes memory _vin) public returns (bool) {
         return BTCUtils.validateVin(_vin);
     }
 
@@ -247,7 +247,7 @@ contract BTCUtilsTest {
     /// @dev         Consider a vin with a valid vout in its scriptsig
     /// @param _vout Raw bytes length-prefixed output vector
     /// @return      True if it represents a validly formatted bout
-    function validateVout(bytes memory _vout) public pure returns (bool) {
+    function validateVout(bytes memory _vout) public returns (bool) {
         return BTCUtils.validateVout(_vout);
     }
 
@@ -261,7 +261,7 @@ contract BTCUtilsTest {
     /// @dev             Use verifyHash256Merkle to verify proofs with this root
     /// @param _header   The header
     /// @return          The merkle root (little-endian)
-    function extractMerkleRootLE(bytes memory _header) public pure returns (bytes32) {
+    function extractMerkleRootLE(bytes memory _header) public returns (bytes32) {
         return BTCUtils.extractMerkleRootLE(_header);
     }
 
@@ -269,7 +269,7 @@ contract BTCUtilsTest {
     /// @dev             Target is a 256 bit number encoded as a 3-byte mantissa and 1 byte exponent
     /// @param _header   The header
     /// @return          The target threshold
-    function extractTarget(bytes memory _header) public pure returns (uint256) {
+    function extractTarget(bytes memory _header) public returns (uint256) {
         return BTCUtils.extractTarget(_header);
     }
 
@@ -278,7 +278,7 @@ contract BTCUtilsTest {
     /// @dev             Difficulty 1 is a 256 bit number encoded as a 3-byte mantissa and 1 byte exponent
     /// @param _target   The current target
     /// @return          The block difficulty (bdiff)
-    function calculateDifficulty(uint256 _target) public pure returns (uint256) {
+    function calculateDifficulty(uint256 _target) public returns (uint256) {
         return BTCUtils.calculateDifficulty(_target);
     }
 
@@ -286,7 +286,7 @@ contract BTCUtilsTest {
     /// @dev             Block headers do NOT include block number :(
     /// @param _header   The header
     /// @return          The previous block's hash (little-endian)
-    function extractPrevBlockLE(bytes memory _header) public pure returns (bytes32) {
+    function extractPrevBlockLE(bytes memory _header) public returns (bytes32) {
         return BTCUtils.extractPrevBlockLE(_header);
     }
 
@@ -294,7 +294,7 @@ contract BTCUtilsTest {
     /// @dev             Time is not 100% reliable
     /// @param _header   The header
     /// @return          The timestamp (little-endian bytes)
-    function extractTimestampLE(bytes memory _header) public pure returns (bytes4) {
+    function extractTimestampLE(bytes memory _header) public returns (bytes4) {
         return BTCUtils.extractTimestampLE(_header);
     }
 
@@ -302,7 +302,7 @@ contract BTCUtilsTest {
     /// @dev             Time is not 100% reliable
     /// @param _header   The header
     /// @return          The timestamp (uint)
-    function extractTimestamp(bytes memory _header) public pure returns (uint32) {
+    function extractTimestamp(bytes memory _header) public returns (uint32) {
         return BTCUtils.extractTimestamp(_header);
     }
 
@@ -310,7 +310,7 @@ contract BTCUtilsTest {
     /// @dev             Does NOT verify the work
     /// @param _header   The header
     /// @return          The difficulty as an integer
-    function extractDifficulty(bytes memory _header) public pure returns (uint256) {
+    function extractDifficulty(bytes memory _header) public returns (uint256) {
         return BTCUtils.extractDifficulty(_header);
     }
 
@@ -318,7 +318,7 @@ contract BTCUtilsTest {
     /// @param _a        The first hash
     /// @param _b        The second hash
     /// @return          The double-sha256 of the concatenated hashes
-    function _hash256MerkleStep(bytes memory _a, bytes memory _b) public view returns (bytes32) {
+    function _hash256MerkleStep(bytes memory _a, bytes memory _b) public returns (bytes32) {
         return BTCUtils._hash256MerkleStep(_a, _b);
     }
 
@@ -327,7 +327,7 @@ contract BTCUtilsTest {
     /// @param _proof    The proof. Tightly packed LE sha256 hashes. The last hash is the root
     /// @param _index    The index of the leaf
     /// @return          true if the proof is valid, else false
-    function verifyHash256Merkle(bytes memory _proof, uint _index) public view returns (bool) {
+    function verifyHash256Merkle(bytes memory _proof, uint _index) public returns (bool) {
         return BTCUtils.verifyHash256Merkle(_proof, _index);
     }
 
@@ -347,7 +347,7 @@ contract BTCUtilsTest {
         uint256 _previousTarget,
         uint256 _firstTimestamp,
         uint256 _secondTimestamp
-    ) public pure returns (uint256) {
+    ) public returns (uint256) {
         return BTCUtils.retargetAlgorithm(_previousTarget, _firstTimestamp, _secondTimestamp);
     }
 }

--- a/solidity/contracts/test/BTCUtilsTest.sol
+++ b/solidity/contracts/test/BTCUtilsTest.sol
@@ -69,6 +69,14 @@ contract BTCUtilsTest {
         return BTCUtils.hash256(_b);
     }
 
+    /// @notice          Implements bitcoin's hash256 (double sha2)
+    /// @dev             abi.encodePacked changes the return to bytes instead of bytes32
+    /// @param _b        The pre-image
+    /// @return          The digest
+    function hash256View(bytes memory _b) public returns (bytes32) {
+        return BTCUtils.hash256View(_b);
+    }
+
     /* ************ */
     /* Legacy Input */
     /* ************ */

--- a/solidity/contracts/test/BTCUtilsTest.sol
+++ b/solidity/contracts/test/BTCUtilsTest.sol
@@ -61,6 +61,14 @@ contract BTCUtilsTest {
         return BTCUtils.hash160(_b);
     }
 
+    /// @notice          Implements bitcoin's hash160 (rmd160(sha2()))
+    /// @dev             abi.encodePacked changes the return to bytes instead of bytes32
+    /// @param _b        The pre-image
+    /// @return          The digest
+    function hash160View(bytes memory _b) public returns (bytes20) {
+        return BTCUtils.hash160View(_b);
+    }
+
     /// @notice          Implements bitcoin's hash256 (double sha2)
     /// @dev             abi.encodePacked changes the return to bytes instead of bytes32
     /// @param _b        The pre-image

--- a/solidity/contracts/test/CheckBitcoinSigsTest.sol
+++ b/solidity/contracts/test/CheckBitcoinSigsTest.sol
@@ -11,7 +11,7 @@ contract CheckBitcoinSigsTest {
     /// @dev             The address is the last 20 bytes of the keccak256 of the address
     /// @param _pubkey   The public key X & Y. Unprefixed, as a 64-byte array
     /// @return          The account address
-    function accountFromPubkey(bytes memory _pubkey) public pure returns (address) {
+    function accountFromPubkey(bytes memory _pubkey) public returns (address) {
         return CheckBitcoinSigs.accountFromPubkey(_pubkey);
     }
 
@@ -19,7 +19,7 @@ contract CheckBitcoinSigsTest {
     /// @dev             Compresses keys to 33 bytes as required by Bitcoin
     /// @param _pubkey   The public key, compressed or uncompressed
     /// @return          The p2wkph output script
-    function p2wpkhFromPubkey(bytes memory _pubkey) public pure returns (bytes memory) {
+    function p2wpkhFromPubkey(bytes memory _pubkey) public returns (bytes memory) {
         return CheckBitcoinSigs.p2wpkhFromPubkey(_pubkey);
     }
 
@@ -37,7 +37,7 @@ contract CheckBitcoinSigsTest {
         uint8 _v,
         bytes32 _r,
         bytes32 _s
-    ) public pure returns (bool) {
+    ) public returns (bool) {
         return CheckBitcoinSigs.checkSig(_pubkey, _digest, _v, _r, _s);
     }
 
@@ -57,7 +57,7 @@ contract CheckBitcoinSigsTest {
         uint8 _v,
         bytes32 _r,
         bytes32 _s
-    ) public pure returns (bool) {
+    ) public returns (bool) {
         return CheckBitcoinSigs.checkBitcoinSig(
             _p2wpkhOutputScript,
             _pubkey,
@@ -74,7 +74,7 @@ contract CheckBitcoinSigsTest {
     function isSha256Preimage(
         bytes memory _candidate,
         bytes32 _digest
-    ) public pure returns (bool) {
+    ) public returns (bool) {
         return CheckBitcoinSigs.isSha256Preimage(_candidate, _digest);
     }
 
@@ -86,7 +86,7 @@ contract CheckBitcoinSigsTest {
     function isKeccak256Preimage(
         bytes memory _candidate,
         bytes32 _digest
-    ) public pure returns (bool) {
+    ) public returns (bool) {
         return CheckBitcoinSigs.isKeccak256Preimage(_candidate, _digest);
     }
 
@@ -104,7 +104,7 @@ contract CheckBitcoinSigsTest {
         bytes8 _inputValue,  // 8-byte LE
         bytes8 _outputValue,  // 8-byte LE
         bytes20 _outputPKH  // 20 byte hash160
-    ) public view returns (bytes32) {
+    ) public returns (bytes32) {
         return CheckBitcoinSigs.oneInputOneOutputSighash(
             _outpoint,
             _inputPKH,

--- a/solidity/contracts/test/ValidateSPVTest.sol
+++ b/solidity/contracts/test/ValidateSPVTest.sol
@@ -30,7 +30,7 @@ contract ValidateSPVTest {
         bytes32 _merkleRoot,
         bytes memory _proof,
         uint _index
-    ) public view returns (bool) {
+    ) public returns (bool) {
         return ValidateSPV.prove(_txid, _merkleRoot, _proof, _index);
     }
 
@@ -46,7 +46,7 @@ contract ValidateSPVTest {
         bytes memory _vin,
         bytes memory _vout,
         bytes4 _locktime
-    ) public view returns (bytes32) {
+    ) public returns (bytes32) {
         return ValidateSPV.calculateTxId(_version, _vin, _vout, _locktime);
     }
 
@@ -54,7 +54,7 @@ contract ValidateSPVTest {
     /// @notice             Compares the hash of each header to the prevHash in the next header
     /// @param _headers     Raw byte array of header chain
     /// @return _reqDiff    The total accumulated difficulty of the header chain
-    function validateHeaderChain(bytes memory _headers) public view returns (uint256 _reqDiff) {
+    function validateHeaderChain(bytes memory _headers) public returns (uint256 _reqDiff) {
         return ValidateSPV.validateHeaderChain(_headers);
     }
 
@@ -62,7 +62,7 @@ contract ValidateSPVTest {
     /// @notice             Compares the hash of each header to the prevHash in the next header
     /// @param _headers     Raw byte array of header chain
     /// @return _reqDiff    The total accumulated difficulty of the header chain
-    function validateHeaderChainTx(bytes memory _headers) public view returns (uint256 _reqDiff) {
+    function validateHeaderChainTx(bytes memory _headers) public returns (uint256 _reqDiff) {
         return ValidateSPV.validateHeaderChain(_headers);
     }
 
@@ -70,7 +70,7 @@ contract ValidateSPVTest {
     /// @param _digest      Header digest
     /// @param _target      The target threshold
     /// @return             true if header work is valid, false otherwise
-    function validateHeaderWork(bytes32 _digest, uint256 _target) public pure returns (bool) {
+    function validateHeaderWork(bytes32 _digest, uint256 _target) public returns (bool) {
         return ValidateSPV.validateHeaderWork(_digest, _target);
     }
 
@@ -79,7 +79,7 @@ contract ValidateSPVTest {
     /// @param _header              The raw bytes header
     /// @param _prevHeaderDigest    The previous header's digest
     /// @return                     true if header chain is valid, false otherwise
-    function validateHeaderPrevHash(bytes memory _header, bytes32 _prevHeaderDigest) public pure returns (bool) {
+    function validateHeaderPrevHash(bytes memory _header, bytes32 _prevHeaderDigest) public returns (bool) {
         return ValidateSPV.validateHeaderPrevHash(_header, _prevHeaderDigest);
     }
 }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "compile": "truffle compile",
-    "test": "cp ../testVectors.json test/ && truffle test",
+    "test": "cp ../testVectors.json test/ && truffle test --reporter eth-gas-reporter",
     "test:coverage": "cp ../testVectors.json test/ && npx solidity-coverage",
     "lint": "solium -d contracts/ && eslint ./test",
     "lint:fix": "solium --fix -d contracts/ && eslint --fix ./test"

--- a/solidity/test/BTCUtils.test.js
+++ b/solidity/test/BTCUtils.test.js
@@ -117,6 +117,14 @@ contract('BTCUtils', () => {
     }
   });
 
+  it('implements bitcoin\'s hash256 as a low-level function', async () => {
+    for (let i = 0; i < hash256.length; i += 1) {
+      await instance.hash256View(hash256[i].input);
+      const res = await instance.hash256View.call(hash256[i].input);
+      assert.strictEqual(res, hash256[i].output);
+    }
+  });
+
   it('implements hash256MerkleStep', async () => {
     for (let i = 0; i < hash256MerkleStep.length; i += 1) {
       /* eslint-disable-next-line */

--- a/solidity/test/BTCUtils.test.js
+++ b/solidity/test/BTCUtils.test.js
@@ -109,6 +109,15 @@ contract('BTCUtils', () => {
     }
   });
 
+  it('implements bitcoin\'s hash160 as a low-level function', async () => {
+    for (let i = 0; i < hash160.length; i += 1) {
+      await instance.hash160View(hash160[i].input);
+      const res = await instance.hash160View.call(hash160[i].input);
+      assert.strictEqual(res, hash160[i].output);
+    }
+  });
+
+
   it('implements bitcoin\'s hash256', async () => {
     for (let i = 0; i < hash256.length; i += 1) {
       await instance.hash256(hash256[i].input);

--- a/solidity/test/BTCUtils.test.js
+++ b/solidity/test/BTCUtils.test.js
@@ -60,7 +60,8 @@ contract('BTCUtils', () => {
 
   it('gets the last bytes correctly', async () => {
     for (let i = 0; i < lastBytes.length; i += 1) {
-      const res = await instance.lastBytes(lastBytes[i].input.bytes, lastBytes[i].input.num);
+      await instance.lastBytes(lastBytes[i].input.bytes, lastBytes[i].input.num);
+      const res = await instance.lastBytes.call(lastBytes[i].input.bytes, lastBytes[i].input.num);
       assert.strictEqual(res, lastBytes[i].output);
     }
   });
@@ -80,19 +81,21 @@ contract('BTCUtils', () => {
 
   it('reverses endianness', async () => {
     for (let i = 0; i < reverseEndianness.length; i += 1) {
-      const res = await instance.reverseEndianness(reverseEndianness[i].input);
+      await instance.reverseEndianness(reverseEndianness[i].input);
+      const res = await instance.reverseEndianness.call(reverseEndianness[i].input);
       assert.strictEqual(res, reverseEndianness[i].output);
     }
   });
 
   it('converts big-endian bytes to integers', async () => {
     for (let i = 0; i < bytesToUint.length; i += 1) {
-      const res = await instance.bytesToUint(bytesToUint[i].input);
+      await instance.bytesToUint(bytesToUint[i].input);
+      const res = await instance.bytesToUint.call(bytesToUint[i].input);
       assert(res, new BN(bytesToUint[i].output, 10));
     }
 
     // max uint256: (2^256)-1
-    const res = await instance.bytesToUint(`0x${'ff'.repeat(32)}`);
+    const res = await instance.bytesToUint.call(`0x${'ff'.repeat(32)}`);
     assert(
       res, new BN('115792089237316195423570985008687907853269984665640564039457584007913129639935', 10)
     );
@@ -100,14 +103,16 @@ contract('BTCUtils', () => {
 
   it('implements bitcoin\'s hash160', async () => {
     for (let i = 0; i < hash160.length; i += 1) {
-      const res = await instance.hash160(hash160[i].input);
+      await instance.hash160(hash160[i].input);
+      const res = await instance.hash160.call(hash160[i].input);
       assert.strictEqual(res, hash160[i].output);
     }
   });
 
   it('implements bitcoin\'s hash256', async () => {
     for (let i = 0; i < hash256.length; i += 1) {
-      const res = await instance.hash256(hash256[i].input);
+      await instance.hash256(hash256[i].input);
+      const res = await instance.hash256.call(hash256[i].input);
       assert.strictEqual(res, hash256[i].output);
     }
   });
@@ -115,7 +120,11 @@ contract('BTCUtils', () => {
   it('implements hash256MerkleStep', async () => {
     for (let i = 0; i < hash256MerkleStep.length; i += 1) {
       /* eslint-disable-next-line */
-      const res = await instance._hash256MerkleStep(
+      await instance._hash256MerkleStep(
+        hash256MerkleStep[i].input[0],
+        hash256MerkleStep[i].input[1]
+      );
+      const res = await instance._hash256MerkleStep.call(
         hash256MerkleStep[i].input[0],
         hash256MerkleStep[i].input[1]
       );
@@ -125,24 +134,28 @@ contract('BTCUtils', () => {
 
   it('extracts a sequence from a witness input as LE and int', async () => {
     for (let i = 0; i < extractSequenceLEWitness.length; i += 1) {
-      const res = await instance.extractSequenceLEWitness(extractSequenceLEWitness[i].input);
+      await instance.extractSequenceLEWitness(extractSequenceLEWitness[i].input);
+      const res = await instance.extractSequenceLEWitness.call(extractSequenceLEWitness[i].input);
       assert.strictEqual(res, extractSequenceLEWitness[i].output);
     }
 
     for (let i = 0; i < extractSequenceWitness.length; i += 1) {
-      const res = await instance.extractSequenceWitness(extractSequenceWitness[i].input);
+      await instance.extractSequenceWitness(extractSequenceWitness[i].input);
+      const res = await instance.extractSequenceWitness.call(extractSequenceWitness[i].input);
       assert(res.eq(new BN(extractSequenceWitness[i].output, 16)));
     }
   });
 
   it('extracts a sequence from a legacy input as LE and int', async () => {
     for (let i = 0; i < extractSequenceLELegacy.length; i += 1) {
-      const res = await instance.extractSequenceLELegacy(extractSequenceLELegacy[i].input);
+      await instance.extractSequenceLELegacy(extractSequenceLELegacy[i].input);
+      const res = await instance.extractSequenceLELegacy.call(extractSequenceLELegacy[i].input);
       assert.strictEqual(res, extractSequenceLELegacy[i].output);
     }
 
     for (let i = 0; i < extractSequenceLegacy.length; i += 1) {
-      const res = await instance.extractSequenceLegacy(extractSequenceLegacy[i].input);
+      await instance.extractSequenceLegacy(extractSequenceLegacy[i].input);
+      const res = await instance.extractSequenceLegacy.call(extractSequenceLegacy[i].input);
       assert(res.eq(new BN(extractSequenceLegacy[i].output, 16)));
     }
   });
@@ -162,28 +175,32 @@ contract('BTCUtils', () => {
 
   it('extracts an outpoint as bytes', async () => {
     for (let i = 0; i < extractOutpoint.length; i += 1) {
-      const res = await instance.extractOutpoint(extractOutpoint[i].input);
+      await instance.extractOutpoint(extractOutpoint[i].input);
+      const res = await instance.extractOutpoint.call(extractOutpoint[i].input);
       assert.strictEqual(res, extractOutpoint[i].output);
     }
   });
 
   it('extracts an outpoint txid', async () => {
     for (let i = 0; i < extractInputTxIdLE.length; i += 1) {
-      const res = await instance.extractInputTxIdLE(extractInputTxIdLE[i].input);
+      await instance.extractInputTxIdLE(extractInputTxIdLE[i].input);
+      const res = await instance.extractInputTxIdLE.call(extractInputTxIdLE[i].input);
       assert.strictEqual(res, extractInputTxIdLE[i].output);
     }
   });
 
   it('extracts an outpoint tx index LE', async () => {
     for (let i = 0; i < extractTxIndexLE.length; i += 1) {
-      const res = await instance.extractTxIndexLE(extractTxIndexLE[i].input);
+      await instance.extractTxIndexLE(extractTxIndexLE[i].input);
+      const res = await instance.extractTxIndexLE.call(extractTxIndexLE[i].input);
       assert.strictEqual(res, extractTxIndexLE[i].output);
     }
   });
 
   it('extracts the hash from a standard output', async () => {
     for (let i = 0; i < extractHash.length; i += 1) {
-      const res = await instance.extractHash(extractHash[i].input);
+      await instance.extractHash(extractHash[i].input);
+      const res = await instance.extractHash.call(extractHash[i].input);
       assert.strictEqual(res, extractHash[i].output);
     }
 
@@ -197,32 +214,36 @@ contract('BTCUtils', () => {
 
   it('extracts the value as LE and int', async () => {
     for (let i = 0; i < extractValueLE.length; i += 1) {
-      const res = await instance.extractValueLE(extractValueLE[i].input);
+      await instance.extractValueLE(extractValueLE[i].input);
+      const res = await instance.extractValueLE.call(extractValueLE[i].input);
       assert.strictEqual(res, extractValueLE[i].output);
     }
 
     for (let i = 0; i < extractValue.length; i += 1) {
-      const res = await instance.extractValue(extractValue[i].input);
+      await instance.extractValue(extractValue[i].input);
+      const res = await instance.extractValue.call(extractValue[i].input);
       assert(res.eq(new BN(extractValue[i].output, 16)));
     }
   });
 
   it('determines input length', async () => {
     for (let i = 0; i < determineInputLength.length; i += 1) {
-      const res = await instance.determineInputLength(determineInputLength[i].input);
+      await instance.determineInputLength(determineInputLength[i].input);
+      const res = await instance.determineInputLength.call(determineInputLength[i].input);
       assert(res.eq(new BN(determineInputLength[i].output, 10)));
     }
   });
 
   it('extracts op_return data blobs', async () => {
     for (let i = 0; i < extractOpReturnData.length; i += 1) {
-      const res = await instance.extractOpReturnData(extractOpReturnData[i].input);
+      await instance.extractOpReturnData(extractOpReturnData[i].input);
+      const res = await instance.extractOpReturnData.call(extractOpReturnData[i].input);
       assert.strictEqual(res, extractOpReturnData[i].output);
     }
 
     for (let i = 0; i < extractOpReturnDataError.length; i += 1) {
       try {
-        const res = await instance.extractOpReturnData(extractOpReturnDataError[i].input);
+        const res = await instance.extractOpReturnData.call(extractOpReturnDataError[i].input);
         assert(!(extractOpReturnDataError[i].solidityError), 'expected an error message');
         assert.isNull(res);
       } catch (e) {
@@ -233,7 +254,11 @@ contract('BTCUtils', () => {
 
   it('extracts inputs at specified indices', async () => {
     for (let i = 0; i < extractInputAtIndex.length; i += 1) {
-      const res = await instance.extractInputAtIndex(
+      await instance.extractInputAtIndex(
+        extractInputAtIndex[i].input.vin,
+        extractInputAtIndex[i].input.index
+      );
+      const res = await instance.extractInputAtIndex.call(
         extractInputAtIndex[i].input.vin,
         extractInputAtIndex[i].input.index
       );
@@ -257,14 +282,16 @@ contract('BTCUtils', () => {
 
   it('sorts legacy from witness inputs', async () => {
     for (let i = 0; i < isLegacyInput.length; i += 1) {
-      const res = await instance.isLegacyInput(isLegacyInput[i].input);
+      await instance.isLegacyInput(isLegacyInput[i].input);
+      const res = await instance.isLegacyInput.call(isLegacyInput[i].input);
       assert.strictEqual(res, isLegacyInput[i].output);
     }
   });
 
   it('extracts the scriptSig from inputs', async () => {
     for (let i = 0; i < extractScriptSig.length; i += 1) {
-      const res = await instance.extractScriptSig(extractScriptSig[i].input);
+      await instance.extractScriptSig(extractScriptSig[i].input);
+      const res = await instance.extractScriptSig.call(extractScriptSig[i].input);
       assert.strictEqual(res, extractScriptSig[i].output);
     }
   });
@@ -284,7 +311,8 @@ contract('BTCUtils', () => {
 
   it('extracts the length of the VarInt and scriptSig from inputs', async () => {
     for (let i = 0; i < extractScriptSigLen.length; i += 1) {
-      const res = await instance.extractScriptSigLen(extractScriptSigLen[i].input);
+      await instance.extractScriptSigLen(extractScriptSigLen[i].input);
+      const res = await instance.extractScriptSigLen.call(extractScriptSigLen[i].input);
       assert(res[0].eq(new BN(extractScriptSigLen[i].output[0], 10)));
       assert(res[1].eq(new BN(extractScriptSigLen[i].output[1], 10)));
     }
@@ -292,7 +320,8 @@ contract('BTCUtils', () => {
 
   it('validates vin length based on stated size', async () => {
     for (let i = 0; i < validateVin.length; i += 1) {
-      const res = await instance.validateVin(validateVin[i].input);
+      await instance.validateVin(validateVin[i].input);
+      const res = await instance.validateVin.call(validateVin[i].input);
       assert.strictEqual(res, validateVin[i].output);
     }
   });
@@ -307,7 +336,8 @@ contract('BTCUtils', () => {
           assert.include(e.message, validateVout[i].solidityError);
         }
       } else {
-        const res = await instance.validateVout(validateVout[i].input);
+        await instance.validateVout(validateVout[i].input);
+        const res = await instance.validateVout.call(validateVout[i].input);
         assert.strictEqual(res, validateVout[i].output);
       }
     }
@@ -315,7 +345,8 @@ contract('BTCUtils', () => {
 
   it('determines output length properly', async () => {
     for (let i = 0; i < determineOutputLength.length; i += 1) {
-      const res = await instance.determineOutputLength(determineOutputLength[i].input);
+      await instance.determineOutputLength(determineOutputLength[i].input);
+      const res = await instance.determineOutputLength.call(determineOutputLength[i].input);
       const expected = new BN(determineOutputLength[i].output, 10);
       assert(
         res.eq(expected),
@@ -326,7 +357,11 @@ contract('BTCUtils', () => {
 
   it('extracts outputs at specified indices', async () => {
     for (let i = 0; i < extractOutputAtIndex.length; i += 1) {
-      const res = await instance.extractOutputAtIndex(
+      await instance.extractOutputAtIndex(
+        extractOutputAtIndex[i].input.vout,
+        extractOutputAtIndex[i].input.index
+      );
+      const res = await instance.extractOutputAtIndex.call(
         extractOutputAtIndex[i].input.vout,
         extractOutputAtIndex[i].input.index
       );
@@ -349,28 +384,32 @@ contract('BTCUtils', () => {
 
   it('extracts a root from a header', async () => {
     for (let i = 0; i < extractMerkleRootLE.length; i += 1) {
-      const res = await instance.extractMerkleRootLE(extractMerkleRootLE[i].input);
+      await instance.extractMerkleRootLE(extractMerkleRootLE[i].input);
+      const res = await instance.extractMerkleRootLE.call(extractMerkleRootLE[i].input);
       assert.strictEqual(res, extractMerkleRootLE[i].output);
     }
   });
 
   it('extracts the target from a header', async () => {
     for (let i = 0; i < extractTarget.length; i += 1) {
-      const res = await instance.extractTarget(extractTarget[i].input);
+      await instance.extractTarget(extractTarget[i].input);
+      const res = await instance.extractTarget.call(extractTarget[i].input);
       assert(res.eq(new BN(extractTarget[i].output.slice(2), 16)));
     }
   });
 
   it('extracts the prev block hash', async () => {
     for (let i = 0; i < extractPrevBlockLE.length; i += 1) {
-      const res = await instance.extractPrevBlockLE(extractPrevBlockLE[i].input);
+      await instance.extractPrevBlockLE(extractPrevBlockLE[i].input);
+      const res = await instance.extractPrevBlockLE.call(extractPrevBlockLE[i].input);
       assert.strictEqual(res, extractPrevBlockLE[i].output);
     }
   });
 
   it('extracts a timestamp from a header', async () => {
     for (let i = 0; i < extractTimestamp.length; i += 1) {
-      const res = await instance.extractTimestamp(extractTimestamp[i].input);
+      await instance.extractTimestamp(extractTimestamp[i].input);
+      const res = await instance.extractTimestamp.call(extractTimestamp[i].input);
       assert.equal(
         res.toNumber(),
         extractTimestamp[i].output
@@ -380,7 +419,11 @@ contract('BTCUtils', () => {
 
   it('verifies a bitcoin merkle root', async () => {
     for (let i = 0; i < verifyHash256Merkle.length; i += 1) {
-      const res = await instance.verifyHash256Merkle(
+      await instance.verifyHash256Merkle(
+        verifyHash256Merkle[i].input.proof,
+        verifyHash256Merkle[i].input.index
+      ); // 0-indexed
+      const res = await instance.verifyHash256Merkle.call(
         verifyHash256Merkle[i].input.proof,
         verifyHash256Merkle[i].input.index
       ); // 0-indexed
@@ -390,14 +433,16 @@ contract('BTCUtils', () => {
 
   it('determines VarInt data lengths correctly', async () => {
     for (let i = 0; i < determineVarIntDataLength.length; i += 1) {
-      const res = await instance.determineVarIntDataLength(`0x${(determineVarIntDataLength[i].input).toString(16)}`);
+      await instance.determineVarIntDataLength(`0x${(determineVarIntDataLength[i].input).toString(16)}`);
+      const res = await instance.determineVarIntDataLength.call(`0x${(determineVarIntDataLength[i].input).toString(16)}`);
       assert(res.eq(new BN(determineVarIntDataLength[i].output, 10)));
     }
   });
 
   it('parses VarInts', async () => {
     for (let i = 0; i < parseVarInt.length; i += 1) {
-      const res = await instance.parseVarInt(parseVarInt[i].input);
+      await instance.parseVarInt(parseVarInt[i].input);
+      const res = await instance.parseVarInt.call(parseVarInt[i].input);
       assert(res[0].eq(new BN(parseVarInt[i].output[0], 10)));
       assert(res[1].eq(new BN(parseVarInt[i].output[1], 10)));
     }
@@ -405,7 +450,8 @@ contract('BTCUtils', () => {
 
   it('returns error for invalid VarInts', async () => {
     for (let i = 0; i < parseVarIntError.length; i += 1) {
-      const res = await instance.parseVarInt(parseVarIntError[i].input);
+      await instance.parseVarInt(parseVarIntError[i].input);
+      const res = await instance.parseVarInt.call(parseVarIntError[i].input);
       assert(res[0].eq(new BN('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 16)), 'did not get error code');
       assert(res[1].eq(new BN(0, 10)), `got non-0 value: ${res[1].toString()}`);
     }
@@ -422,17 +468,20 @@ contract('BTCUtils', () => {
       secondTimestamp = retargetAlgorithm[i].input[1].timestamp;
       previousTarget = await instance.extractTarget.call(retargetAlgorithm[i].input[1].hex);
       expectedNewTarget = await instance.extractTarget.call(retargetAlgorithm[i].input[2].hex);
-      res = await instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp);
+      await instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp);
+      res = await instance.retargetAlgorithm.call(previousTarget, firstTimestamp, secondTimestamp);
       // (response & expected) == expected
       // this converts our full-length target into truncated block target
       assert(res.uand(expectedNewTarget).eq(expectedNewTarget));
 
       secondTimestamp = firstTimestamp + 5 * 2016 * 10 * 60; // longer than 4x
-      res = await instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp);
+      await instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp);
+      res = await instance.retargetAlgorithm.call(previousTarget, firstTimestamp, secondTimestamp);
       assert(res.divn(4).uand(previousTarget).eq(previousTarget));
 
       secondTimestamp = firstTimestamp + 2016 * 10 * 14; // shorter than 1/4x
-      res = await instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp);
+      await instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp);
+      res = await instance.retargetAlgorithm.call(previousTarget, firstTimestamp, secondTimestamp);
       assert(res.muln(4).uand(previousTarget).eq(previousTarget));
     }
   });
@@ -441,15 +490,18 @@ contract('BTCUtils', () => {
     let actual;
     let expected;
     for (let i = 0; i < retargetAlgorithm.length; i += 1) {
-      actual = await instance.extractDifficulty(retargetAlgorithm[i].input[0].hex);
+      await instance.extractDifficulty(retargetAlgorithm[i].input[0].hex);
+      actual = await instance.extractDifficulty.call(retargetAlgorithm[i].input[0].hex);
       expected = new BN(retargetAlgorithm[i].input[0].difficulty, 10);
       assert(actual.eq(expected));
 
-      actual = await instance.extractDifficulty(retargetAlgorithm[i].input[1].hex);
+      await instance.extractDifficulty(retargetAlgorithm[i].input[1].hex);
+      actual = await instance.extractDifficulty.call(retargetAlgorithm[i].input[1].hex);
       expected = new BN(retargetAlgorithm[i].input[1].difficulty, 10);
       assert(actual.eq(expected));
 
-      actual = await instance.extractDifficulty(retargetAlgorithm[i].input[2].hex);
+      await instance.extractDifficulty(retargetAlgorithm[i].input[2].hex);
+      actual = await instance.extractDifficulty.call(retargetAlgorithm[i].input[2].hex);
       expected = new BN(retargetAlgorithm[i].input[2].difficulty, 10);
       assert(actual.eq(expected));
     }

--- a/solidity/test/CheckBitcoinSigs.test.js
+++ b/solidity/test/CheckBitcoinSigs.test.js
@@ -19,7 +19,8 @@ contract('CheckBitcoinSigs', async () => {
 
   describe('#accountFromPubkey', async () => {
     it('generates an account from a pubkey', async () => {
-      const res = await instance.accountFromPubkey('0x33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333');
+      await instance.accountFromPubkey('0x33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333');
+      const res = await instance.accountFromPubkey.call('0x33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333');
       assert.equal(res.toLowerCase(), '0x183671cd69c7f9a760f9f1c59393df69e893e557');
     });
 
@@ -40,17 +41,20 @@ contract('CheckBitcoinSigs', async () => {
     const outputScript = '0x00143bc28d6d92d9073fb5e3adf481795eaf446bceed';
 
     it('handles unprefixed uncompressed keys', async () => {
-      const res = await instance.p2wpkhFromPubkey(uncompressed);
+      await instance.p2wpkhFromPubkey(uncompressed);
+      const res = await instance.p2wpkhFromPubkey.call(uncompressed);
       assert.equal(res, outputScript);
     });
 
     it('handles prefixed uncompressed keys', async () => {
-      const res = await instance.p2wpkhFromPubkey(prefixedUncompressed);
+      await instance.p2wpkhFromPubkey(prefixedUncompressed);
+      const res = await instance.p2wpkhFromPubkey.call(prefixedUncompressed);
       assert.equal(res, outputScript);
     });
 
     it('handles compressed keys', async () => {
-      const res = await instance.p2wpkhFromPubkey(compressed);
+      await instance.p2wpkhFromPubkey(compressed);
+      const res = await instance.p2wpkhFromPubkey.call(compressed);
       assert.equal(res, outputScript);
     });
 
@@ -69,12 +73,14 @@ contract('CheckBitcoinSigs', async () => {
     // signing with privkey '11' * 32
     // using RFC 6979 nonce (libsecp256k1)
     it('validates signatures', async () => {
-      const res = await instance.checkSig(pubkey, digest, v, r, s);
+      await instance.checkSig(pubkey, digest, v, r, s);
+      const res = await instance.checkSig.call(pubkey, digest, v, r, s);
       assert.isTrue(res);
     });
 
     it('fails on bad signatures', async () => {
-      const res = await instance.checkSig(pubkey, digest, 28, r, s);
+      await instance.checkSig(pubkey, digest, 28, r, s);
+      const res = await instance.checkSig.call(pubkey, digest, 28, r, s);
       assert.isFalse(res);
     });
 
@@ -90,17 +96,20 @@ contract('CheckBitcoinSigs', async () => {
   describe('#checkBitcoinSig', async () => {
     const witnessScript = '0x0014fc7250a211deddc70ee5a2738de5f07817351cef';
     it('returns false if the pubkey does not match the witness script', async () => {
-      const res = await instance.checkBitcoinSig('0x00', pubkey, constants.EMPTY, 1, constants.EMPTY, constants.EMPTY);
+      await instance.checkBitcoinSig('0x00', pubkey, constants.EMPTY, 1, constants.EMPTY, constants.EMPTY);
+      const res = await instance.checkBitcoinSig.call('0x00', pubkey, constants.EMPTY, 1, constants.EMPTY, constants.EMPTY);
       assert.isFalse(res);
     });
 
     it('returns true if the signature is valid and matches the script', async () => {
-      const res = await instance.checkBitcoinSig(witnessScript, pubkey, digest, v, r, s);
+      await instance.checkBitcoinSig(witnessScript, pubkey, digest, v, r, s);
+      const res = await instance.checkBitcoinSig.call(witnessScript, pubkey, digest, v, r, s);
       assert.isTrue(res);
     });
 
     it('returns false if the signature is invalid', async () => {
-      const res = await instance.checkBitcoinSig(witnessScript, pubkey, digest, v + 1, r, s);
+      await instance.checkBitcoinSig(witnessScript, pubkey, digest, v + 1, r, s);
+      const res = await instance.checkBitcoinSig.call(witnessScript, pubkey, digest, v + 1, r, s);
       assert.isFalse(res);
     });
 
@@ -117,13 +126,17 @@ contract('CheckBitcoinSigs', async () => {
   describe('#isSha256Preimage', async () => {
     it('identifies sha256 preimages', async () => {
       let res;
-      res = await instance.isSha256Preimage('0x01', '0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a');
+      await instance.isSha256Preimage('0x01', '0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a');
+      res = await instance.isSha256Preimage.call('0x01', '0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a');
       assert.isTrue(res);
-      res = await instance.isSha256Preimage('0x02', '0xdbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986');
+      await instance.isSha256Preimage('0x02', '0xdbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986');
+      res = await instance.isSha256Preimage.call('0x02', '0xdbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986');
       assert.isTrue(res);
-      res = await instance.isSha256Preimage('0x03', '0x084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5');
+      await instance.isSha256Preimage('0x03', '0x084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5');
+      res = await instance.isSha256Preimage.call('0x03', '0x084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5');
       assert.isTrue(res);
-      res = await instance.isSha256Preimage('0x04', '0x084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5');
+      await instance.isSha256Preimage('0x04', '0x084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5');
+      res = await instance.isSha256Preimage.call('0x04', '0x084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5');
       assert.isFalse(res);
     });
   });
@@ -131,13 +144,17 @@ contract('CheckBitcoinSigs', async () => {
   describe('#isKeccak256Preimage', async () => {
     it('identifies keccak256 preimages', async () => {
       let res;
-      res = await instance.isKeccak256Preimage('0x01', '0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2');
+      await instance.isKeccak256Preimage('0x01', '0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2');
+      res = await instance.isKeccak256Preimage.call('0x01', '0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2');
       assert.isTrue(res);
-      res = await instance.isKeccak256Preimage('0x02', '0xf2ee15ea639b73fa3db9b34a245bdfa015c260c598b211bf05a1ecc4b3e3b4f2');
+      await instance.isKeccak256Preimage('0x02', '0xf2ee15ea639b73fa3db9b34a245bdfa015c260c598b211bf05a1ecc4b3e3b4f2');
+      res = await instance.isKeccak256Preimage.call('0x02', '0xf2ee15ea639b73fa3db9b34a245bdfa015c260c598b211bf05a1ecc4b3e3b4f2');
       assert.isTrue(res);
-      res = await instance.isKeccak256Preimage('0x03', '0x69c322e3248a5dfc29d73c5b0553b0185a35cd5bb6386747517ef7e53b15e287');
+      await instance.isKeccak256Preimage('0x03', '0x69c322e3248a5dfc29d73c5b0553b0185a35cd5bb6386747517ef7e53b15e287');
+      res = await instance.isKeccak256Preimage.call('0x03', '0x69c322e3248a5dfc29d73c5b0553b0185a35cd5bb6386747517ef7e53b15e287');
       assert.isTrue(res);
-      res = await instance.isKeccak256Preimage('0x04', '0x69c322e3248a5dfc29d73c5b0553b0185a35cd5bb6386747517ef7e53b15e287');
+      await instance.isKeccak256Preimage('0x04', '0x69c322e3248a5dfc29d73c5b0553b0185a35cd5bb6386747517ef7e53b15e287');
+      res = await instance.isKeccak256Preimage.call('0x04', '0x69c322e3248a5dfc29d73c5b0553b0185a35cd5bb6386747517ef7e53b15e287');
       assert.isFalse(res);
     });
   });
@@ -161,7 +178,14 @@ contract('CheckBitcoinSigs', async () => {
     // == hash160(023333333333333333333333333333333333333333333333333333333333333333)
 
     it('calculates the sighash of a bizarre transaction that for some reason we need ;)', async () => {
-      const res = await instance.oneInputOneOutputSighash(
+      await instance.oneInputOneOutputSighash(
+        outpoint,
+        inputPKH,
+        inputValue,
+        outputValue,
+        outputPKH
+      );
+      const res = await instance.oneInputOneOutputSighash.call(
         outpoint,
         inputPKH,
         inputValue,

--- a/solidity/test/ValidateSPV.test.js
+++ b/solidity/test/ValidateSPV.test.js
@@ -46,7 +46,8 @@ contract('ValidateSPV', () => {
         const {
           txIdLE, merkleRootLE, proof, index
         } = prove[i].input;
-        const res = await instance.prove(txIdLE, merkleRootLE, proof, index);
+        await instance.prove(txIdLE, merkleRootLE, proof, index);
+        const res = await instance.prove.call(txIdLE, merkleRootLE, proof, index);
         assert.strictEqual(res, prove[i].output);
       }
     });
@@ -58,7 +59,8 @@ contract('ValidateSPV', () => {
         const {
           version, vin, vout, locktime
         } = calculateTxId[i].input;
-        const res = await instance.calculateTxId(version, vin, vout, locktime);
+        await instance.calculateTxId(version, vin, vout, locktime);
+        const res = await instance.calculateTxId.call(version, vin, vout, locktime);
         assert.strictEqual(res, calculateTxId[i].output);
       }
     });
@@ -67,7 +69,8 @@ contract('ValidateSPV', () => {
   describe('#validateHeaderChain', async () => {
     it('returns true if header chain is valid', async () => {
       for (let i = 0; i < validateHeaderChain.length; i += 1) {
-        const res = await instance.validateHeaderChain(validateHeaderChain[i].input);
+        await instance.validateHeaderChain(validateHeaderChain[i].input);
+        const res = await instance.validateHeaderChain.call(validateHeaderChain[i].input);
 
         // Execute within Tx to measure gas amount
         await instance.validateHeaderChainTx(validateHeaderChain[i].input);
@@ -78,7 +81,8 @@ contract('ValidateSPV', () => {
 
     it('returns error if header chain is invalid', async () => {
       for (let i = 0; i < validateHeaderChainError.length; i += 1) {
-        const res = await instance.validateHeaderChain(validateHeaderChainError[i].input);
+        await instance.validateHeaderChain(validateHeaderChainError[i].input);
+        const res = await instance.validateHeaderChain.call(validateHeaderChainError[i].input);
 
         // Execute within Tx to measure gas amount
         await instance.validateHeaderChainTx(validateHeaderChainError[i].input);
@@ -93,7 +97,8 @@ contract('ValidateSPV', () => {
       for (let i = 0; i < validateHeaderWork.length; i += 1) {
         const { digest, target } = validateHeaderWork[i].input;
         // Is this right?
-        const res = await instance.validateHeaderWork(digest, target);
+        await instance.validateHeaderWork(digest, target);
+        const res = await instance.validateHeaderWork.call(digest, target);
         assert.strictEqual(res, validateHeaderWork[i].output);
       }
     });
@@ -102,7 +107,11 @@ contract('ValidateSPV', () => {
   describe('#validateHeaderPrevHash', async () => {
     it('returns true if header prevHash is valid', async () => {
       for (let i = 0; i < validateHeaderPrevHash.length; i += 1) {
-        const res = await instance.validateHeaderPrevHash(
+        await instance.validateHeaderPrevHash(
+          validateHeaderPrevHash[i].input.header,
+          validateHeaderPrevHash[i].input.prevHash
+        );
+        const res = await instance.validateHeaderPrevHash.call(
           validateHeaderPrevHash[i].input.header,
           validateHeaderPrevHash[i].input.prevHash
         );

--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -70,7 +70,8 @@ module.exports = {
     reporterOptions : {
       excludeContracts: [],
       currency: 'USD',
-      gasPrice: 10
+      gasPrice: 10,
+      src: 'contracts/test'
     }
   },
 


### PR DESCRIPTION
Fix the reporting of gas costs and add minor improvements to how hashing is used. Most importantly, expose a low-level `hash160View` similar to `hash256View`.